### PR TITLE
Add Better Auth UI sign-in components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,4 @@
-"use client";
-
-import { SignedIn, SignedOut, UserButton } from "@daveyplate/better-auth-ui";
-import Link from "next/link";
+import { AuthStatus } from "@/components/auth-status";
 
 export default function Home() {
   return (
@@ -16,20 +13,7 @@ export default function Home() {
           </p>
         </div>
 
-        <div className="flex flex-col items-center gap-4">
-          <SignedIn>
-            <UserButton />
-          </SignedIn>
-
-          <SignedOut>
-            <Link
-              href="/auth/sign-in"
-              className="rounded-lg bg-white px-8 py-3 font-semibold text-slate-900 transition hover:bg-slate-100"
-            >
-              Sign in
-            </Link>
-          </SignedOut>
-        </div>
+        <AuthStatus />
       </div>
     </main>
   );

--- a/src/components/auth-status.tsx
+++ b/src/components/auth-status.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { SignedIn, SignedOut, UserButton } from "@daveyplate/better-auth-ui";
+import Link from "next/link";
+
+export function AuthStatus() {
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <SignedIn>
+        <UserButton />
+      </SignedIn>
+
+      <SignedOut>
+        <Link
+          href="/auth/sign-in"
+          className="rounded-lg bg-white px-8 py-3 font-semibold text-slate-900 transition hover:bg-slate-100"
+        >
+          Sign in
+        </Link>
+      </SignedOut>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add Better Auth UI library for polished email/password authentication
- Initialize shadcn/ui with Sonner toaster for notifications
- Make GitHub OAuth optional (can be enabled later via env vars)
- Add incremental commit guidelines to AGENTS.md

## Changes
- **Dependencies**: Added `@daveyplate/better-auth-ui`, shadcn/ui deps
- **Auth routes**: `/auth/sign-in`, `/auth/sign-up`, `/auth/forgot-password`, etc.
- **Components**: AuthUIProvider, Sonner toaster
- **Config**: GitHub OAuth now optional in `src/env.js`

## Verification
```bash
bun run check  # passes
bun run dev    # visit /auth/sign-in to test
```