### PR TITLE
fix: optimistic ui after create client

### DIFF
--- a/src/app/clients/page.tsx
+++ b/src/app/clients/page.tsx
@@ -106,11 +106,18 @@ export default function ClientsPage() {
   );
 
   // Callback to remove optimistic client after real one is created
-  const handleOptimisticSuccess = useCallback((optimisticId: string) => {
-    setOptimisticClients((prev) =>
-      prev.filter((client) => client.id !== optimisticId),
-    );
-  }, []);
+  const handleOptimisticSuccess = useCallback(
+    (optimisticId: string, realClient: unknown) => {
+      // Remove the optimistic client
+      setOptimisticClients((prev) =>
+        prev.filter((client) => client.id !== optimisticId),
+      );
+
+      // Add the real client to the top of the list
+      setClients((prev) => [realClient as Client, ...prev]);
+    },
+    [],
+  );
 
   // Callback to handle optimistic creation failure
   const handleOptimisticError = useCallback((optimisticId: string) => {

--- a/src/components/clients/create/clients-create-client.tsx
+++ b/src/components/clients/create/clients-create-client.tsx
@@ -27,7 +27,7 @@ interface CreateClientDialogProps {
     dateOfBirth: string;
     province: string;
   }) => string;
-  onOptimisticSuccess?: (optimisticId: string) => void;
+  onOptimisticSuccess?: (optimisticId: string, realClient: unknown) => void;
   onOptimisticError?: (optimisticId: string) => void;
 }
 

--- a/src/components/clients/create/use-client-form.ts
+++ b/src/components/clients/create/use-client-form.ts
@@ -13,7 +13,7 @@ interface UseClientFormOptions {
     dateOfBirth: string;
     province: string;
   }) => string;
-  onOptimisticSuccess?: (optimisticId: string) => void;
+  onOptimisticSuccess?: (optimisticId: string, realClient: unknown) => void;
   onOptimisticError?: (optimisticId: string) => void;
 }
 
@@ -115,13 +115,16 @@ export function useClientForm(
   };
 
   // Helper: Handle successful submission
-  const handleSuccess = (optimisticId: string | undefined) => {
+  const handleSuccess = (
+    optimisticId: string | undefined,
+    createdClient: unknown,
+  ) => {
     toast.success("Client created successfully");
     resetForm();
     router.refresh();
 
     if (optimisticId && options?.onOptimisticSuccess) {
-      options.onOptimisticSuccess(optimisticId);
+      options.onOptimisticSuccess(optimisticId, createdClient);
     }
 
     if (onSuccess) {
@@ -212,8 +215,8 @@ export function useClientForm(
         throw new Error(errorData.error || "Failed to create client");
       }
 
-      await response.json();
-      handleSuccess(optimisticId);
+      const responseData = await response.json();
+      handleSuccess(optimisticId, responseData.client);
     } catch (error) {
       handleError(error, optimisticId);
     } finally {


### PR DESCRIPTION
This pull request improves the optimistic client creation flow by ensuring that the real client returned from the backend is added to the client list after a successful creation. The changes update the relevant callback signatures and logic to pass and handle the real client object, rather than just removing the optimistic entry.

**Optimistic client creation improvements:**

* Updated the `onOptimisticSuccess` callback signature in both `CreateClientDialogProps` and `UseClientFormOptions` interfaces to accept the real client object in addition to the optimistic ID. [[1]](diffhunk://#diff-04692f750d11f1856080de6d241af3d879b59e53ddff504b3062f87f76a6a75eL30-R30) [[2]](diffhunk://#diff-f2449c71fe530740f20f47362ca7da103a36a1679ff1b172735b33c9b18d58f8L16-R16)
* Modified the `handleSuccess` function in `useClientForm` to pass the real client object to the `onOptimisticSuccess` callback.
* Updated the client creation logic in `useClientForm` to extract the created client from the backend response and pass it to `handleSuccess`.
* Enhanced the `handleOptimisticSuccess` callback in `ClientsPage` to add the real client to the top of the client list after removing the optimistic entry.