### PR TITLE
fix(auth): remove dynamicParams to allow runtime path resolution

### DIFF
--- a/src/app/auth/[path]/page.tsx
+++ b/src/app/auth/[path]/page.tsx
@@ -1,8 +1,6 @@
 import { AuthView } from "@daveyplate/better-auth-ui";
 import { authViewPaths } from "@daveyplate/better-auth-ui/server";
 
-export const dynamicParams = false;
-
 export function generateStaticParams() {
   return Object.values(authViewPaths).map((path) => ({ path }));
 }


### PR DESCRIPTION
## Summary

- Removes `dynamicParams = false` from the auth page to fix 404 errors on Cloudflare Workers

## Problem

Auth pages (`/auth/sign-in`, `/auth/sign-up`, etc.) were returning 404 errors on the Cloudflare Workers deployment. The `dynamicParams = false` setting was preventing any paths not pre-generated at build time from being served.

## Solution

Remove `dynamicParams = false` while keeping `generateStaticParams()`. This allows:
- Pre-rendered pages to be served from the edge (best performance)
- Dynamic fallback for any paths not statically generated

## Testing

- `bun run check` passes
- Manual verification: auth pages should load on deployed Workers