### PR TITLE
feat(report): add print report functionality

### DIFF
--- a/src/components/clients/client-report-view.tsx
+++ b/src/components/clients/client-report-view.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 import {
   User,
   Calendar,
@@ -17,6 +18,7 @@ import {
   Heart,
   Cigarette,
   FileText,
+  Printer,
 } from "lucide-react";
 import type { Client } from "@/types/client";
 import type { Asset } from "@/types/asset";
@@ -94,20 +96,36 @@ export function ClientReportView({ client, clientId }: ClientReportViewProps) {
   // Calculate totals using shared utility
   const { total: totalAssets } = calculateAssetTotals(assets);
 
+  const handlePrint = () => {
+    window.print();
+  };
+
   return (
     <div className="space-y-6 print:space-y-4">
       {/* Report Header */}
       <div className="border-b pb-4 print:pb-2">
-        <div className="text-muted-foreground mb-1 flex items-center gap-2 text-sm">
-          <FileText className="h-4 w-4" />
-          <span>Financial Needs Analysis Report</span>
+        <div className="flex items-start justify-between">
+          <div>
+            <div className="text-muted-foreground mb-1 flex items-center gap-2 text-sm">
+              <FileText className="h-4 w-4" />
+              <span>Financial Needs Analysis Report</span>
+            </div>
+            <h2 className="text-2xl font-bold print:text-xl">
+              {client.firstName} {client.lastName}
+            </h2>
+            <p className="text-muted-foreground text-sm">
+              Generated: {formatDateTime(new Date().toISOString())}
+            </p>
+          </div>
+          <Button
+            onClick={handlePrint}
+            variant="outline"
+            className="print:hidden"
+          >
+            <Printer className="mr-2 h-4 w-4" />
+            Print Report
+          </Button>
         </div>
-        <h2 className="text-2xl font-bold print:text-xl">
-          {client.firstName} {client.lastName}
-        </h2>
-        <p className="text-muted-foreground text-sm">
-          Generated: {formatDateTime(new Date().toISOString())}
-        </p>
       </div>
 
       {/* Client Snapshot */}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -343,3 +343,57 @@
     }
   }
 }
+
+/* =============================================================================
+   PRINT STYLES
+   Ensures clean, readable output when printing reports
+   ============================================================================= */
+@media print {
+  /* Hide navigation and non-essential UI elements */
+  nav,
+  [data-sonner-toaster] {
+    display: none !important;
+  }
+
+  /* Reset body for print */
+  body {
+    background: white !important;
+    color: black !important;
+    font-size: 12pt;
+    line-height: 1.4;
+  }
+
+  /* Ensure cards have visible borders in print */
+  .card,
+  [class*="Card"] {
+    border: 1px solid #e5e7eb !important;
+    box-shadow: none !important;
+    break-inside: avoid;
+  }
+
+  /* Handle page breaks */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    break-after: avoid;
+  }
+
+  /* Ensure charts and visualizations are visible */
+  .recharts-wrapper {
+    break-inside: avoid;
+  }
+
+  /* Print-friendly link styling */
+  a {
+    text-decoration: none !important;
+    color: inherit !important;
+  }
+
+  /* Ensure adequate margins */
+  @page {
+    margin: 1.5cm;
+  }
+}


### PR DESCRIPTION
## Summary

Adds print and save-as-PDF support for the client report view using the browser's native print functionality.

## Changes

- Add "Print Report" button to the report header (hidden when printing)
- Add print-specific CSS to `globals.css`:
  - Hide navigation and toaster during print
  - Style cards with visible borders
  - Prevent page breaks inside cards and charts
  - Set proper page margins (1.5cm)

## Acceptance Criteria

- [x] A "Print report" button is available on the report view
- [x] Clicking the button triggers the browser print dialog
- [x] Report prints cleanly (no navigation chrome or non-essential elements, reasonable page breaks)
- [x] No custom PDF generation service required

## Testing

- Verified ESLint passes (0 errors)
- Verified TypeScript passes (0 errors)
- Verified 37/37 unit tests pass
- Verified production build succeeds

Closes #66