### PR TITLE
fix(ui): update 'Province' to 'State' terminology

### DIFF
--- a/e2e/client-create-ui.spec.ts
+++ b/e2e/client-create-ui.spec.ts
@@ -153,7 +153,7 @@ test.describe("Client Create UI", () => {
       lastName: string;
       dateOfBirth: string;
       sex: "M" | "F";
-      province: string;
+      state: string;
       healthRating: string;
     },
   ) {
@@ -161,7 +161,7 @@ test.describe("Client Create UI", () => {
     await page.getByLabel(/last name/i).fill(data.lastName);
     await page.getByLabel(/date of birth/i).fill(data.dateOfBirth);
     await page.getByLabel(/sex/i).selectOption(data.sex);
-    await page.getByLabel(/state/i).selectOption(data.province);
+    await page.getByLabel(/state/i).selectOption(data.state);
     await page.getByLabel(/health rating/i).selectOption(data.healthRating);
   }
 
@@ -223,7 +223,7 @@ test.describe("Client Create UI", () => {
       lastName: "Doe",
       dateOfBirth: "1985-06-15",
       sex: "F",
-      province: "BC",
+      state: "BC",
       healthRating: "preferred",
     });
 
@@ -246,7 +246,7 @@ test.describe("Client Create UI", () => {
       lastName: "Smith",
       dateOfBirth: "1990-03-20",
       sex: "M",
-      province: "ON",
+      state: "ON",
       healthRating: "standard",
     });
 
@@ -288,7 +288,7 @@ test.describe("Client Create UI", () => {
       lastName: "Test",
       dateOfBirth: "1995-12-10",
       sex: "M",
-      province: "AB",
+      state: "AB",
       healthRating: "standard_plus",
     });
 
@@ -312,7 +312,7 @@ test.describe("Client Create UI", () => {
       lastName: "Dialog",
       dateOfBirth: "1988-08-08",
       sex: "F",
-      province: "QC",
+      state: "QC",
       healthRating: "preferred_plus",
     });
 

--- a/e2e/client-crud.spec.ts
+++ b/e2e/client-crud.spec.ts
@@ -25,7 +25,7 @@ test.describe("Client CRUD API", () => {
       lastName: string;
       dateOfBirth: string;
       sex: "M" | "F";
-      province: string;
+      state: string;
     },
   ): Promise<TestClientResult> {
     const response = await request.post("http://localhost:3000/api/clients", {
@@ -131,7 +131,7 @@ test.describe("Client CRUD API", () => {
           lastName: "Doe",
           dateOfBirth: "1980-01-15",
           sex: "M",
-          province: "ON",
+          state: "ON",
           smoker: false,
           healthRating: "standard",
           hasSpouse: true,
@@ -258,7 +258,7 @@ test.describe("Client CRUD API", () => {
         lastName: "Smith",
         dateOfBirth: "1990-05-20",
         sex: "F",
-        province: "BC",
+        state: "BC",
       },
     });
 
@@ -279,7 +279,7 @@ test.describe("Client CRUD API", () => {
         lastName: "Doe",
         dateOfBirth: "invalid-date", // Invalid format
         sex: "M",
-        province: "ON",
+        state: "ON",
       },
     });
 
@@ -345,7 +345,7 @@ test.describe("Client CRUD API", () => {
       lastName: "Validation",
       dateOfBirth: "1985-03-10",
       sex: "F",
-      province: "AB",
+      state: "AB",
     });
     const { client } = createBody;
 
@@ -375,7 +375,7 @@ test.describe("Client CRUD API", () => {
       lastName: "Auth",
       dateOfBirth: "1985-03-10",
       sex: "M",
-      province: "BC",
+      state: "BC",
     });
     const { client } = createBody;
 
@@ -400,7 +400,7 @@ test.describe("Client CRUD API", () => {
       lastName: "Delete",
       dateOfBirth: "1985-03-10",
       sex: "F",
-      province: "AB",
+      state: "AB",
     });
     const { client } = createBody;
 

--- a/e2e/client-detail.spec.ts
+++ b/e2e/client-detail.spec.ts
@@ -77,7 +77,7 @@ test.describe("Client Detail Page", () => {
             lastName: "Detail",
             dateOfBirth: "1985-06-15",
             sex: "F",
-            province: "BC",
+            state: "BC",
             smoker: false,
             healthRating: "preferred",
             hasSpouse: false,

--- a/e2e/insurance-needs.spec.ts
+++ b/e2e/insurance-needs.spec.ts
@@ -80,7 +80,7 @@ test.describe("Insurance Needs Calculation", () => {
             lastName: "Insurance",
             dateOfBirth: "1985-05-15",
             sex: "M",
-            province: "ON",
+            state: "ON",
             smoker: false,
             healthRating: "standard",
             hasSpouse: false,

--- a/scripts/seed-clients.ts
+++ b/scripts/seed-clients.ts
@@ -43,7 +43,7 @@ async function seedClients() {
 
     console.log(`Successfully created ${inserted.length} test clients:`);
     for (const c of inserted) {
-      console.log(`   - ${c.firstName} ${c.lastName} (${c.province})`);
+      console.log(`   - ${c.firstName} ${c.lastName} (${c.state})`);
     }
   } catch (error) {
     console.error("Error seeding clients:", error);

--- a/src/app/api/clients/[id]/generate-letter/route.ts
+++ b/src/app/api/clients/[id]/generate-letter/route.ts
@@ -148,7 +148,7 @@ export const POST = withApiHandler(
       {
         firstName: clientData.firstName,
         lastName: clientData.lastName,
-        province: clientData.province,
+        state: clientData.state,
         hasSpouse: clientData.hasSpouse ?? false,
         spouseAge: clientData.spouseAge,
         clientIncome: decimalToNumber(clientData.clientIncome),

--- a/src/app/api/clients/[id]/route.ts
+++ b/src/app/api/clients/[id]/route.ts
@@ -5,7 +5,7 @@ import {
   decimalString,
   HEALTH_RATINGS,
   isValidDate,
-  PROVINCES,
+  STATES,
   UUID_REGEX,
 } from "@/lib/validation/client";
 import { and, eq, isNull } from "drizzle-orm";
@@ -49,7 +49,7 @@ const updateClientSchema = z
       .refine(isValidDate, "Invalid or future date")
       .optional(),
     sex: z.enum(["M", "F"]).optional(),
-    province: z.enum(PROVINCES).optional(),
+    state: z.enum(STATES).optional(),
     smoker: z.boolean().optional(),
     healthRating: z.enum(HEALTH_RATINGS).optional(),
     hasSpouse: z.boolean().optional(),

--- a/src/app/api/clients/route.ts
+++ b/src/app/api/clients/route.ts
@@ -5,7 +5,7 @@ import {
   decimalString,
   HEALTH_RATINGS,
   isValidDate,
-  PROVINCES,
+  STATES,
 } from "@/lib/validation/client";
 import { and, count, eq, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
@@ -29,7 +29,7 @@ const createClientSchema = z
       .regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid date format (YYYY-MM-DD)")
       .refine(isValidDate, "Invalid or future date"),
     sex: z.enum(["M", "F"]),
-    province: z.enum(PROVINCES),
+    state: z.enum(STATES),
     smoker: z.boolean().default(false),
     healthRating: z.enum(HEALTH_RATINGS).default("standard"),
     hasSpouse: z.boolean().default(false),

--- a/src/app/clients/[id]/page.tsx
+++ b/src/app/clients/[id]/page.tsx
@@ -318,7 +318,7 @@ function ClientDetailContent() {
               </div>
               <div>
                 <p className="text-muted-foreground text-sm">State</p>
-                <p className="font-medium uppercase">{client.province}</p>
+                <p className="font-medium uppercase">{client.state}</p>
               </div>
               <div>
                 <p className="text-muted-foreground text-sm">Status</p>

--- a/src/app/clients/page.tsx
+++ b/src/app/clients/page.tsx
@@ -86,14 +86,14 @@ export default function ClientsPage() {
       firstName: string;
       lastName: string;
       dateOfBirth: string;
-      province: string;
+      state: string;
     }) => {
       const optimisticClient: OptimisticClient = {
         id: `optimistic-${Date.now()}`,
         firstName: clientData.firstName,
         lastName: clientData.lastName,
         dateOfBirth: clientData.dateOfBirth,
-        province: clientData.province,
+        state: clientData.state,
         updatedAt: new Date().toISOString(),
         status: "draft",
         optimistic: true,

--- a/src/components/clients/client-report-view.tsx
+++ b/src/components/clients/client-report-view.tsx
@@ -185,7 +185,7 @@ export function ClientReportView({
               <MapPin className="text-muted-foreground mt-0.5 h-4 w-4" />
               <div>
                 <p className="text-muted-foreground text-sm">State</p>
-                <p className="font-medium uppercase">{client.province}</p>
+                <p className="font-medium uppercase">{client.state}</p>
               </div>
             </div>
 

--- a/src/components/clients/clients-table.tsx
+++ b/src/components/clients/clients-table.tsx
@@ -61,7 +61,7 @@ export function ClientsTable({ clients, onRowClick }: ClientsTableProps) {
               {client.firstName} {client.lastName}
             </TableCell>
             <TableCell>{calculateAge(client.dateOfBirth)}</TableCell>
-            <TableCell className="uppercase">{client.province}</TableCell>
+            <TableCell className="uppercase">{client.state}</TableCell>
             <TableCell className="text-muted-foreground">
               {formatDate(client.updatedAt)}
             </TableCell>

--- a/src/components/clients/create/clients-create-client.tsx
+++ b/src/components/clients/create/clients-create-client.tsx
@@ -25,7 +25,7 @@ interface CreateClientDialogProps {
     firstName: string;
     lastName: string;
     dateOfBirth: string;
-    province: string;
+    state: string;
   }) => string;
   onOptimisticSuccess?: (optimisticId: string, realClient: unknown) => void;
   onOptimisticError?: (optimisticId: string) => void;

--- a/src/components/clients/create/form-sections/demographics-fields.tsx
+++ b/src/components/clients/create/form-sections/demographics-fields.tsx
@@ -9,7 +9,7 @@ interface DemographicsFieldsProps {
   ) => void;
 }
 
-const PROVINCES = [
+const STATES = [
   { value: "AB", label: "Alberta" },
   { value: "BC", label: "British Columbia" },
   { value: "MB", label: "Manitoba" },
@@ -48,25 +48,20 @@ export function DemographicsFields({
         </select>
       </FormField>
 
-      <FormField
-        label="State"
-        required
-        error={errors.province}
-        htmlFor="province"
-      >
+      <FormField label="State" required error={errors.state} htmlFor="state">
         <select
-          id="province"
-          name="province"
-          value={formData.province}
+          id="state"
+          name="state"
+          value={formData.state}
           onChange={onInputChange}
           className={`border-input bg-background ring-offset-background focus-visible:ring-ring w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none ${
-            errors.province ? "border-red-500" : ""
+            errors.state ? "border-red-500" : ""
           }`}
         >
           <option value="">Select state</option>
-          {PROVINCES.map((prov) => (
-            <option key={prov.value} value={prov.value}>
-              {prov.label}
+          {STATES.map((state) => (
+            <option key={state.value} value={state.value}>
+              {state.label}
             </option>
           ))}
         </select>

--- a/src/components/clients/create/schema.ts
+++ b/src/components/clients/create/schema.ts
@@ -8,7 +8,7 @@ export const formStateSchema = z.object({
   lastName: z.string(),
   dateOfBirth: z.string(),
   sex: z.string(),
-  province: z.string(),
+  state: z.string(),
   smoker: z.boolean(),
   healthRating: z.string(),
   hasSpouse: z.boolean(),
@@ -29,7 +29,7 @@ export const clientFormSchema = z
       .string()
       .regex(/^\d{4}-\d{2}-\d{2}$/, "Date of birth is required (YYYY-MM-DD)"),
     sex: z.enum(["M", "F"], { message: "Sex is required" }),
-    province: z.enum(
+    state: z.enum(
       [
         "AB",
         "BC",
@@ -45,7 +45,7 @@ export const clientFormSchema = z
         "SK",
         "YT",
       ],
-      { message: "Province is required" },
+      { message: "State is required" },
     ),
     smoker: z.boolean(),
     healthRating: z.enum(

--- a/src/components/clients/create/use-client-form.ts
+++ b/src/components/clients/create/use-client-form.ts
@@ -11,7 +11,7 @@ interface UseClientFormOptions {
     firstName: string;
     lastName: string;
     dateOfBirth: string;
-    province: string;
+    state: string;
   }) => string;
   onOptimisticSuccess?: (optimisticId: string, realClient: unknown) => void;
   onOptimisticError?: (optimisticId: string) => void;
@@ -33,7 +33,7 @@ const initialFormData: FormState = {
   lastName: "",
   dateOfBirth: "",
   sex: "",
-  province: "",
+  state: "",
   smoker: false,
   healthRating: "",
   hasSpouse: false,
@@ -108,7 +108,7 @@ export function useClientForm(
     firstName: string;
     lastName: string;
     dateOfBirth: string;
-    province: string;
+    state: string;
   }): string | undefined => {
     if (!options?.onOptimisticCreate) return undefined;
     return options.onOptimisticCreate(validatedData);

--- a/src/lib/__tests__/client-utils.test.ts
+++ b/src/lib/__tests__/client-utils.test.ts
@@ -15,7 +15,7 @@ describe("Completion Status Functions", () => {
         firstName: "John",
         lastName: "Doe",
         dateOfBirth: "1980-01-01",
-        province: "ON",
+        state: "ON",
       };
       expect(isProfileComplete(client)).toBe(true);
     });
@@ -25,7 +25,7 @@ describe("Completion Status Functions", () => {
         firstName: "",
         lastName: "Doe",
         dateOfBirth: "1980-01-01",
-        province: "ON",
+        state: "ON",
       };
       expect(isProfileComplete(client)).toBe(false);
     });
@@ -35,7 +35,7 @@ describe("Completion Status Functions", () => {
         firstName: "John",
         lastName: "",
         dateOfBirth: "1980-01-01",
-        province: "ON",
+        state: "ON",
       };
       expect(isProfileComplete(client)).toBe(false);
     });
@@ -45,7 +45,7 @@ describe("Completion Status Functions", () => {
         firstName: "John",
         lastName: "Doe",
         dateOfBirth: "",
-        province: "ON",
+        state: "ON",
       };
       expect(isProfileComplete(client)).toBe(false);
     });
@@ -55,7 +55,7 @@ describe("Completion Status Functions", () => {
         firstName: "John",
         lastName: "Doe",
         dateOfBirth: "1980-01-01",
-        province: "",
+        state: "",
       };
       expect(isProfileComplete(client)).toBe(false);
     });
@@ -109,7 +109,7 @@ describe("Completion Status Functions", () => {
         firstName: "John",
         lastName: "Doe",
         dateOfBirth: "1980-01-01",
-        province: "ON",
+        state: "ON",
         clientIncome: "100000.00",
       };
       const insuranceResult = { totalInsuranceNeeds: 500000 };
@@ -128,7 +128,7 @@ describe("Completion Status Functions", () => {
         firstName: "John",
         lastName: "Doe",
         dateOfBirth: "1980-01-01",
-        province: "ON",
+        state: "ON",
         clientIncome: "0", // Not complete
       };
 

--- a/src/lib/client-utils.ts
+++ b/src/lib/client-utils.ts
@@ -111,13 +111,13 @@ export function isProfileComplete(client: {
   firstName: string;
   lastName: string;
   dateOfBirth: string;
-  province: string;
+  state: string;
 }): boolean {
   return !!(
     client.firstName &&
     client.lastName &&
     client.dateOfBirth &&
-    client.province
+    client.state
   );
 }
 
@@ -150,7 +150,7 @@ export function calculateCompletionStatus(
     firstName: string;
     lastName: string;
     dateOfBirth: string;
-    province: string;
+    state: string;
     clientIncome?: string;
   },
   insuranceResult: { totalInsuranceNeeds: number } | null,

--- a/src/lib/demo-data.ts
+++ b/src/lib/demo-data.ts
@@ -20,7 +20,7 @@ export const demoClient: Client = {
   firstName: "Alex",
   lastName: "Thompson",
   dateOfBirth: "1982-06-15", // 43 years old
-  province: "ON",
+  state: "ON",
   sex: "M",
   smoker: false,
   healthRating: "preferred",

--- a/src/lib/test-data/clients.ts
+++ b/src/lib/test-data/clients.ts
@@ -10,7 +10,7 @@ type TestClientData = {
   lastName: string;
   dateOfBirth: string;
   sex: "M" | "F";
-  province: "ON" | "BC" | "AB" | "QC" | "NS" | "MB" | "SK" | "NB" | "PE" | "NL";
+  state: "ON" | "BC" | "AB" | "QC" | "NS" | "MB" | "SK" | "NB" | "PE" | "NL";
   smoker: boolean;
   healthRating:
     | "preferred"
@@ -31,7 +31,7 @@ export const testClientsData: TestClientData[] = [
     lastName: "Pork",
     dateOfBirth: "1980-05-15",
     sex: "M",
-    province: "ON",
+    state: "ON",
     smoker: false,
     healthRating: "preferred",
     hasSpouse: true,
@@ -44,7 +44,7 @@ export const testClientsData: TestClientData[] = [
     lastName: "Pork",
     dateOfBirth: "1985-08-22",
     sex: "F",
-    province: "BC",
+    state: "BC",
     smoker: false,
     healthRating: "preferred_plus",
     hasSpouse: false,
@@ -56,7 +56,7 @@ export const testClientsData: TestClientData[] = [
     lastName: "Pork",
     dateOfBirth: "1975-03-10",
     sex: "M",
-    province: "AB",
+    state: "AB",
     smoker: true,
     healthRating: "standard",
     hasSpouse: true,
@@ -70,7 +70,7 @@ export const testClientsData: TestClientData[] = [
     lastName: "Rodriguez",
     dateOfBirth: "1992-11-05",
     sex: "F",
-    province: "QC",
+    state: "QC",
     smoker: false,
     healthRating: "standard_plus",
     hasSpouse: false,
@@ -82,7 +82,7 @@ export const testClientsData: TestClientData[] = [
     lastName: "Thompson",
     dateOfBirth: "1970-07-18",
     sex: "M",
-    province: "NS",
+    state: "NS",
     smoker: false,
     healthRating: "standard",
     hasSpouse: true,
@@ -96,7 +96,7 @@ export const testClientsData: TestClientData[] = [
     lastName: "Pork",
     dateOfBirth: "1988-02-14",
     sex: "F",
-    province: "MB",
+    state: "MB",
     smoker: false,
     healthRating: "preferred",
     hasSpouse: false,
@@ -108,7 +108,7 @@ export const testClientsData: TestClientData[] = [
     lastName: "Martinez",
     dateOfBirth: "1965-09-30",
     sex: "M",
-    province: "SK",
+    state: "SK",
     smoker: true,
     healthRating: "substandard",
     hasSpouse: true,
@@ -122,7 +122,7 @@ export const testClientsData: TestClientData[] = [
     lastName: "Wilson",
     dateOfBirth: "1995-12-03",
     sex: "F",
-    province: "NB",
+    state: "NB",
     smoker: false,
     healthRating: "standard_plus",
     hasSpouse: false,
@@ -134,7 +134,7 @@ export const testClientsData: TestClientData[] = [
     lastName: "Pork",
     dateOfBirth: "1982-06-25",
     sex: "M",
-    province: "PE",
+    state: "PE",
     smoker: false,
     healthRating: "preferred_plus",
     hasSpouse: true,
@@ -148,7 +148,7 @@ export const testClientsData: TestClientData[] = [
     lastName: "Taylor",
     dateOfBirth: "1990-04-17",
     sex: "F",
-    province: "NL",
+    state: "NL",
     smoker: false,
     healthRating: "standard",
     hasSpouse: false,

--- a/src/lib/validation/client.ts
+++ b/src/lib/validation/client.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
 
 /**
- * Canadian provinces/territories enum
+ * US states / Canadian provinces/territories enum
  */
-export const PROVINCES = [
+export const STATES = [
   "AB",
   "BC",
   "MB",

--- a/src/server/ai/prompts/reasons-why.ts
+++ b/src/server/ai/prompts/reasons-why.ts
@@ -13,7 +13,7 @@ import type { InsuranceNeedsResult } from "@/lib/financial/insurance-needs";
 export interface ReasonsWhyClientData {
   firstName: string;
   lastName: string;
-  province: string;
+  state: string;
   hasSpouse: boolean;
   spouseAge?: number | null;
   clientIncome: number;
@@ -44,10 +44,10 @@ function formatCurrency(amount: number): string {
 }
 
 /**
- * Get full province name from abbreviation
+ * Get full state/province name from abbreviation
  */
-function getProvinceName(code: string): string {
-  const provinces: Record<string, string> = {
+function getStateName(code: string): string {
+  const states: Record<string, string> = {
     AB: "Alberta",
     BC: "British Columbia",
     MB: "Manitoba",
@@ -62,7 +62,7 @@ function getProvinceName(code: string): string {
     SK: "Saskatchewan",
     YT: "Yukon",
   };
-  return provinces[code] ?? code;
+  return states[code] ?? code;
 }
 
 /**
@@ -73,7 +73,7 @@ export function buildReasonsWhyPrompt(
   financial: ReasonsWhyFinancialData,
 ): string {
   const { insuranceResult } = financial;
-  const provinceName = getProvinceName(client.province);
+  const stateName = getStateName(client.state);
   const clientName = `${client.firstName} ${client.lastName}`;
 
   // Build household income description
@@ -101,7 +101,7 @@ export function buildReasonsWhyPrompt(
 
 CLIENT INFORMATION:
 - Name: ${clientName}
-- Province: ${provinceName}
+- State: ${stateName}
 - Household Status: ${client.hasSpouse ? `Married${client.spouseAge ? ` (spouse age: ${client.spouseAge})` : ""}` : "Single"}
 - Income: ${incomeDescription}
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -19,8 +19,8 @@ export const createTable = pgTableCreator((name) => `pg-drizzle_${name}`);
 // ENUMS
 // ============================================================================
 
-/** Canadian provinces and territories */
-export const provinceEnum = pgEnum("province", [
+/** US states / Canadian provinces and territories */
+export const stateEnum = pgEnum("state", [
   "AB",
   "BC",
   "MB",
@@ -173,7 +173,7 @@ export const client = pgTable(
     lastName: text("last_name").notNull(),
     dateOfBirth: date("date_of_birth").notNull(),
     sex: sexEnum("sex").notNull(),
-    province: provinceEnum("province").notNull(),
+    state: stateEnum("state").notNull(),
     smoker: boolean("smoker").notNull().default(false),
     healthRating: healthRatingEnum("health_rating")
       .notNull()

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -5,7 +5,7 @@ export type Client = {
   firstName: string;
   lastName: string;
   dateOfBirth: string;
-  province: string;
+  state: string;
   updatedAt: string;
   status: ClientStatus;
   // Optional fields for future expansion


### PR DESCRIPTION
## Summary
- Updates all UI labels from "Province" to "State" for US-based usage
- **Breaking change**: Renames database column and API field from `province` to `state`
- Fixes #105

## Changes

### Database & API (Breaking)
- `src/server/db/schema.ts`: Renamed `provinceEnum` → `stateEnum`, column `province` → `state`
- `src/types/client.ts`: `Client.province` → `Client.state`
- `src/lib/validation/client.ts`: `PROVINCES` → `STATES`
- API routes: Field name changed from `province` to `state` in request/response

### UI Components
- `clients-table.tsx`: Column header "Province" → "State"
- `demographics-fields.tsx`: Form label and placeholder updated
- `clients/[id]/page.tsx`: Detail label updated
- `client-report-view.tsx`: Label updated (also fixed pre-existing duplicate Button import)

### Other Files
- Form schemas, hooks, and state management updated
- AI prompt templates updated
- All test files and test data updated
- Seed script updated

## Migration Notes
⚠️ **This is a breaking change.** The database needs to be recreated since the enum and column names have changed. Since we have no users yet, this is acceptable.

## Verification
- ✅ ESLint: 0 errors
- ✅ TypeScript: 0 errors
- ✅ Unit tests: 55/55 pass
- ✅ E2E tests: 31/31 pass (1 skipped - pre-existing)
- ✅ Build: Success