### PR TITLE
perf(db): add composite indexes for auth tables

### DIFF
--- a/drizzle/0004_add_auth_indexes.sql
+++ b/drizzle/0004_add_auth_indexes.sql
@@ -1,0 +1,11 @@
+-- Add indexes for session and account tables
+-- Improves lookup performance for authentication operations
+
+-- Index for looking up sessions by user (auth checks, session listing)
+CREATE INDEX "session_user_id_idx" ON "session" USING btree ("user_id");--> statement-breakpoint
+
+-- Index for looking up accounts by user  
+CREATE INDEX "account_user_id_idx" ON "account" USING btree ("user_id");--> statement-breakpoint
+
+-- Unique constraint to prevent duplicate OAuth accounts (same provider + account combo)
+CREATE UNIQUE INDEX "account_provider_account_idx" ON "account" USING btree ("provider_id","account_id");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1769566263858,
       "tag": "0003_remarkable_shatterstar",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1769136000000,
+      "tag": "0004_add_auth_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -10,6 +10,7 @@ import {
   pgTableCreator,
   text,
   timestamp,
+  uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
 
@@ -106,36 +107,52 @@ export const user = pgTable("user", {
     .notNull(),
 });
 
-export const session = pgTable("session", {
-  id: text("id").primaryKey(),
-  expiresAt: timestamp("expires_at").notNull(),
-  token: text("token").notNull().unique(),
-  createdAt: timestamp("created_at").notNull(),
-  updatedAt: timestamp("updated_at").notNull(),
-  ipAddress: text("ip_address"),
-  userAgent: text("user_agent"),
-  userId: text("user_id")
-    .notNull()
-    .references(() => user.id, { onDelete: "cascade" }),
-});
+export const session = pgTable(
+  "session",
+  {
+    id: text("id").primaryKey(),
+    expiresAt: timestamp("expires_at").notNull(),
+    token: text("token").notNull().unique(),
+    createdAt: timestamp("created_at").notNull(),
+    updatedAt: timestamp("updated_at").notNull(),
+    ipAddress: text("ip_address"),
+    userAgent: text("user_agent"),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+  },
+  (t) => [
+    // Index for looking up sessions by user (auth checks, session listing)
+    index("session_user_id_idx").on(t.userId),
+  ],
+);
 
-export const account = pgTable("account", {
-  id: text("id").primaryKey(),
-  accountId: text("account_id").notNull(),
-  providerId: text("provider_id").notNull(),
-  userId: text("user_id")
-    .notNull()
-    .references(() => user.id, { onDelete: "cascade" }),
-  accessToken: text("access_token"),
-  refreshToken: text("refresh_token"),
-  idToken: text("id_token"),
-  accessTokenExpiresAt: timestamp("access_token_expires_at"),
-  refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
-  scope: text("scope"),
-  password: text("password"),
-  createdAt: timestamp("created_at").notNull(),
-  updatedAt: timestamp("updated_at").notNull(),
-});
+export const account = pgTable(
+  "account",
+  {
+    id: text("id").primaryKey(),
+    accountId: text("account_id").notNull(),
+    providerId: text("provider_id").notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    accessToken: text("access_token"),
+    refreshToken: text("refresh_token"),
+    idToken: text("id_token"),
+    accessTokenExpiresAt: timestamp("access_token_expires_at"),
+    refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+    scope: text("scope"),
+    password: text("password"),
+    createdAt: timestamp("created_at").notNull(),
+    updatedAt: timestamp("updated_at").notNull(),
+  },
+  (t) => [
+    // Index for looking up accounts by user
+    index("account_user_id_idx").on(t.userId),
+    // Unique constraint to prevent duplicate OAuth accounts (same provider + account combo)
+    uniqueIndex("account_provider_account_idx").on(t.providerId, t.accountId),
+  ],
+);
 
 export const verification = pgTable("verification", {
   id: text("id").primaryKey(),


### PR DESCRIPTION
## Summary

Adds database indexes for session and account tables to improve authentication query performance.

## Changes

- Add `session_user_id_idx` index on `session.userId` for faster session lookups by user
- Add `account_user_id_idx` index on `account.userId` for faster account lookups by user
- Add unique index `account_provider_account_idx` on `(providerId, accountId)` to prevent duplicate OAuth accounts

## Migration

Migration file `drizzle/0004_add_auth_indexes.sql` included. Run `bun run db:migrate` to apply.

## Why

Without these indexes, auth-related queries (session validation, account lookups) require full table scans. As the user base grows, this would degrade performance for every authenticated request.

Closes #95