### PR TITLE
fix(validation): add max value and age range validation

### DIFF
--- a/src/app/api/clients/[id]/route.ts
+++ b/src/app/api/clients/[id]/route.ts
@@ -4,6 +4,7 @@ import { createLogger } from "@/server/axiom";
 import {
   decimalString,
   HEALTH_RATINGS,
+  isValidClientAge,
   isValidDate,
   STATES,
   UUID_REGEX,
@@ -47,6 +48,7 @@ const updateClientSchema = z
       .string()
       .regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid date format")
       .refine(isValidDate, "Invalid or future date")
+      .refine(isValidClientAge, "Client must be between 18 and 120 years old")
       .optional(),
     sex: z.enum(["M", "F"]).optional(),
     state: z.enum(STATES).optional(),

--- a/src/app/api/clients/route.ts
+++ b/src/app/api/clients/route.ts
@@ -4,6 +4,7 @@ import { createLogger } from "@/server/axiom";
 import {
   decimalString,
   HEALTH_RATINGS,
+  isValidClientAge,
   isValidDate,
   STATES,
 } from "@/lib/validation/client";
@@ -27,7 +28,8 @@ const createClientSchema = z
     dateOfBirth: z
       .string()
       .regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid date format (YYYY-MM-DD)")
-      .refine(isValidDate, "Invalid or future date"),
+      .refine(isValidDate, "Invalid or future date")
+      .refine(isValidClientAge, "Client must be between 18 and 120 years old"),
     sex: z.enum(["M", "F"]),
     state: z.enum(STATES),
     smoker: z.boolean().default(false),

--- a/src/lib/validation/__tests__/client.test.ts
+++ b/src/lib/validation/__tests__/client.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+  decimalString,
+  isValidClientAge,
+  isValidDate,
+  MAX_MONEY_VALUE,
+  MIN_CLIENT_AGE,
+  MAX_CLIENT_AGE,
+} from "../client";
+
+describe("isValidDate", () => {
+  it("accepts valid dates in YYYY-MM-DD format", () => {
+    expect(isValidDate("2000-01-15")).toBe(true);
+    expect(isValidDate("1990-12-31")).toBe(true);
+    expect(isValidDate("2020-02-29")).toBe(true); // leap year
+  });
+
+  it("rejects invalid date structures", () => {
+    expect(isValidDate("2023-02-30")).toBe(false); // Feb 30 doesn't exist
+    expect(isValidDate("2023-04-31")).toBe(false); // April has 30 days
+    expect(isValidDate("2023-13-01")).toBe(false); // Invalid month
+    expect(isValidDate("2021-02-29")).toBe(false); // Not a leap year
+  });
+
+  it("rejects future dates", () => {
+    const futureDate = new Date();
+    futureDate.setFullYear(futureDate.getFullYear() + 1);
+    const futureDateStr = futureDate.toISOString().split("T")[0];
+    expect(isValidDate(futureDateStr!)).toBe(false);
+  });
+
+  it("accepts today's date", () => {
+    const today = new Date().toISOString().split("T")[0];
+    expect(isValidDate(today!)).toBe(true);
+  });
+
+  it("rejects malformed date strings", () => {
+    expect(isValidDate("not-a-date")).toBe(false);
+    expect(isValidDate("2023/01/15")).toBe(false);
+    expect(isValidDate("15-01-2023")).toBe(false);
+    expect(isValidDate("")).toBe(false);
+  });
+});
+
+describe("isValidClientAge", () => {
+  const getDateYearsAgo = (years: number): string => {
+    const date = new Date();
+    date.setFullYear(date.getFullYear() - years);
+    return date.toISOString().split("T")[0]!;
+  };
+
+  it("accepts ages within valid range (18-120)", () => {
+    expect(isValidClientAge(getDateYearsAgo(18))).toBe(true);
+    expect(isValidClientAge(getDateYearsAgo(30))).toBe(true);
+    expect(isValidClientAge(getDateYearsAgo(65))).toBe(true);
+    expect(isValidClientAge(getDateYearsAgo(120))).toBe(true);
+  });
+
+  it("rejects ages below minimum", () => {
+    expect(isValidClientAge(getDateYearsAgo(17))).toBe(false);
+    expect(isValidClientAge(getDateYearsAgo(10))).toBe(false);
+    expect(isValidClientAge(getDateYearsAgo(0))).toBe(false);
+  });
+
+  it("rejects ages above maximum", () => {
+    expect(isValidClientAge(getDateYearsAgo(121))).toBe(false);
+    expect(isValidClientAge(getDateYearsAgo(150))).toBe(false);
+  });
+
+  it("handles edge case of birthday not yet occurred this year", () => {
+    // Create a date that's exactly 18 years ago minus 1 day
+    // This person is still 17 until tomorrow
+    const date = new Date();
+    date.setFullYear(date.getFullYear() - 18);
+    date.setDate(date.getDate() + 1); // birthday is tomorrow
+    const dateStr = date.toISOString().split("T")[0]!;
+    expect(isValidClientAge(dateStr)).toBe(false);
+  });
+
+  it("exports correct constants", () => {
+    expect(MIN_CLIENT_AGE).toBe(18);
+    expect(MAX_CLIENT_AGE).toBe(120);
+  });
+});
+
+describe("decimalString", () => {
+  const incomeValidator = decimalString("income");
+
+  it("accepts valid decimal strings", () => {
+    expect(incomeValidator.safeParse("0").success).toBe(true);
+    expect(incomeValidator.safeParse("100").success).toBe(true);
+    expect(incomeValidator.safeParse("100.00").success).toBe(true);
+    expect(incomeValidator.safeParse("75000.50").success).toBe(true);
+    expect(incomeValidator.safeParse("999999999999.99").success).toBe(true);
+  });
+
+  it("rejects invalid formats", () => {
+    expect(incomeValidator.safeParse("-100").success).toBe(false); // negative
+    expect(incomeValidator.safeParse("100.001").success).toBe(false); // too many decimals
+    expect(incomeValidator.safeParse("abc").success).toBe(false); // non-numeric
+    expect(incomeValidator.safeParse("").success).toBe(false); // empty
+    expect(incomeValidator.safeParse("100,000").success).toBe(false); // comma
+    expect(incomeValidator.safeParse(".50").success).toBe(false); // no leading digit
+  });
+
+  it("rejects values exceeding max", () => {
+    const result = incomeValidator.safeParse("9999999999999.99"); // exceeds max
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts custom max value", () => {
+    const percentValidator = decimalString("percent", 100);
+    expect(percentValidator.safeParse("100").success).toBe(true);
+    expect(percentValidator.safeParse("100.00").success).toBe(true);
+
+    const overMaxResult = percentValidator.safeParse("100.01");
+    expect(overMaxResult.success).toBe(false);
+  });
+
+  it("exports correct max money constant", () => {
+    expect(MAX_MONEY_VALUE).toBe(999_999_999_999.99);
+  });
+});

--- a/src/lib/validation/client.ts
+++ b/src/lib/validation/client.ts
@@ -31,6 +31,14 @@ export const HEALTH_RATINGS = [
 ] as const;
 
 /**
+ * Validation constants for financial fields
+ * MAX_MONEY_VALUE matches PostgreSQL decimal(14, 2) - max 12 digits before decimal
+ */
+export const MAX_MONEY_VALUE = 999_999_999_999.99; // ~1 trillion
+export const MIN_CLIENT_AGE = 18;
+export const MAX_CLIENT_AGE = 120;
+
+/**
  * Validates a date string is a valid date (not just format) and not in the future.
  * Uses UTC consistently to avoid timezone-related edge cases.
  */
@@ -69,10 +77,46 @@ export function isValidDate(dateStr: string): boolean {
 }
 
 /**
+ * Validates that a date of birth represents a person between MIN_CLIENT_AGE and MAX_CLIENT_AGE years old.
+ * Insurance clients must be adults (18+) and realistically under 120.
+ */
+export function isValidClientAge(dateStr: string): boolean {
+  const parts = dateStr.split("-").map(Number);
+  const year = parts[0];
+  const month = parts[1];
+  const day = parts[2];
+
+  if (year === undefined || month === undefined || day === undefined) {
+    return false;
+  }
+
+  const today = new Date();
+  const birthDate = new Date(Date.UTC(year, month - 1, day));
+
+  // Calculate age
+  let age = today.getUTCFullYear() - birthDate.getUTCFullYear();
+  const monthDiff = today.getUTCMonth() - birthDate.getUTCMonth();
+  const dayDiff = today.getUTCDate() - birthDate.getUTCDate();
+
+  // Adjust if birthday hasn't occurred yet this year
+  if (monthDiff < 0 || (monthDiff === 0 && dayDiff < 0)) {
+    age--;
+  }
+
+  return age >= MIN_CLIENT_AGE && age <= MAX_CLIENT_AGE;
+}
+
+/**
  * Decimal string validation - matches PostgreSQL decimal format.
  * Allows positive numbers with optional 2 decimal places.
+ *
+ * @param fieldName - Human-readable field name for error messages
+ * @param maxValue - Optional maximum value (defaults to MAX_MONEY_VALUE)
  */
-export const decimalString = (fieldName: string) =>
+export const decimalString = (
+  fieldName: string,
+  maxValue: number = MAX_MONEY_VALUE,
+) =>
   z
     .string()
     .regex(/^\d+(\.\d{1,2})?$/, `Invalid ${fieldName} format`)
@@ -82,6 +126,15 @@ export const decimalString = (fieldName: string) =>
         return !isNaN(num) && num >= 0;
       },
       { message: `${fieldName} must be a non-negative number` },
+    )
+    .refine(
+      (val) => {
+        const num = parseFloat(val);
+        return num <= maxValue;
+      },
+      {
+        message: `${fieldName} must not exceed ${maxValue.toLocaleString()}`,
+      },
     );
 
 /**


### PR DESCRIPTION
## Summary

Improves Zod schema validation for better data integrity by adding bounds checking on financial and age fields.

## Changes

### Validation Improvements
- **Max value validation for money fields**: All decimal fields (clientIncome, spouseIncome, existingLifeInsuranceCoverage) now have a max value of ~$1 trillion, matching the PostgreSQL `decimal(14, 2)` precision
- **Client age validation**: dateOfBirth now validates that the client is between 18-120 years old (insurance clients must be adults)

### New Test Coverage
- Added comprehensive unit tests for `isValidDate`, `isValidClientAge`, and `decimalString` validation utilities
- Tests cover edge cases like leap years, invalid dates, age boundary conditions

## Files Changed
- `src/lib/validation/client.ts` - Added `isValidClientAge`, `MAX_MONEY_VALUE`, age constants, updated `decimalString` with max value
- `src/app/api/clients/route.ts` - Added age validation to createClientSchema
- `src/app/api/clients/[id]/route.ts` - Added age validation to updateClientSchema  
- `src/lib/validation/__tests__/client.test.ts` - New test file with 15 tests

## Note

The original issue suggested converting decimal strings to `z.coerce.number()`. After review, this would be a **regression** - the decimal string format is intentional to preserve precision for financial calculations. PostgreSQL `decimal` columns are represented as strings in Drizzle to avoid JavaScript floating-point precision loss.

Closes #93