### PR TITLE
fix(onboarding): guard missing session user id in onboarding flow

### DIFF
--- a/src/app/api/onboarding/profile/route.ts
+++ b/src/app/api/onboarding/profile/route.ts
@@ -1,27 +1,36 @@
 import { eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
 
 import {
   deriveOnboardingPrefill,
   isOnboardingProfileComplete,
   onboardingProfileSchema,
 } from "@/lib/onboarding";
+import { getSessionUserId } from "@/lib/auth/session-utils";
 import {
   handleValidationError,
   parseJsonBody,
   withApiHandler,
 } from "@/lib/api/route-helpers";
 import { getDb } from "@/server/db";
-import { user, userProfile } from "@/server/db/schemas";
+import { userProfile } from "@/server/db/schemas/user-profile-schema";
+import { user } from "@/server/db/schemas/auth-schema";
 
 export const GET = withApiHandler(
   {
     endpoint: "/api/onboarding/profile",
     method: "GET",
   },
-  async (_request, { session }) => {
+  async (_request, { logger, session }) => {
+    const userId = getSessionUserId(session);
+    if (!userId) {
+      await logger.warn("Unauthorized access attempt");
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     const db = getDb();
     const profile = await db.query.userProfile.findFirst({
-      where: eq(userProfile.userId, session.user.id),
+      where: eq(userProfile.userId, userId),
     });
 
     const prefill = deriveOnboardingPrefill(session.user.name);
@@ -51,6 +60,12 @@ export const PUT = withApiHandler(
     method: "PUT",
   },
   async (request, { logger, session }) => {
+    const userId = getSessionUserId(session);
+    if (!userId) {
+      await logger.warn("Unauthorized access attempt");
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     const bodyResult = await parseJsonBody(request, logger);
     if ("error" in bodyResult) return bodyResult.error;
 
@@ -71,7 +86,7 @@ export const PUT = withApiHandler(
     await db
       .insert(userProfile)
       .values({
-        userId: session.user.id,
+        userId,
         firstName: data.firstName,
         lastName: data.lastName,
         state: data.state,
@@ -102,7 +117,7 @@ export const PUT = withApiHandler(
         name: fullName,
         updatedAt: now,
       })
-      .where(eq(user.id, session.user.id));
+      .where(eq(user.id, userId));
 
     await logger.info("Onboarding profile updated", {
       statusCode: 200,

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -7,6 +7,7 @@ import {
   isOnboardingProfileComplete,
 } from "@/lib/onboarding";
 import { AUTHENTICATED_HOME_ROUTE } from "@/lib/app-routes";
+import { getSessionUserId } from "@/lib/auth/session-utils";
 import { resolveOnboardingAccountType } from "@/lib/role-experience";
 import { getSession } from "@/server/better-auth/server";
 import { getDb } from "@/server/db";
@@ -19,14 +20,15 @@ export default async function OnboardingPage({
   searchParams: Promise<{ role?: string | string[] }>;
 }) {
   const session = await getSession();
+  const userId = getSessionUserId(session);
 
-  if (!session?.user) {
+  if (!session?.user || !userId) {
     redirect("/auth/sign-in");
   }
 
   const db = getDb();
   const profile = await db.query.userProfile.findFirst({
-    where: eq(userProfile.userId, session.user.id),
+    where: eq(userProfile.userId, userId),
   });
 
   if (isOnboardingProfileComplete(profile)) {

--- a/src/lib/api/route-helpers.ts
+++ b/src/lib/api/route-helpers.ts
@@ -5,6 +5,7 @@ import { userProfile } from "@/server/db/schemas";
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { validateUUID, verifyClientOwnership } from "./client-helpers";
+import { getSessionUserId } from "@/lib/auth/session-utils";
 
 /**
  * Context passed to API route handlers
@@ -173,15 +174,24 @@ export async function validateSession(
   logger: Logger,
 ): Promise<{ session: Session } | { error: NextResponse }> {
   const session = await getSession();
+  const userId = getSessionUserId(session);
 
-  if (!session?.user) {
+  if (!session?.user || !userId) {
     await logger.warn("Unauthorized access attempt");
     return {
       error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
     };
   }
 
-  return { session };
+  const normalizedSession = {
+    ...session,
+    user: {
+      ...session.user,
+      id: userId,
+    },
+  } as Session;
+
+  return { session: normalizedSession };
 }
 
 export async function validateAdvisorSession(

--- a/src/lib/auth/__tests__/session-utils.test.ts
+++ b/src/lib/auth/__tests__/session-utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { getSessionUserId } from "../session-utils";
+
+describe("getSessionUserId", () => {
+  it("returns user.id when present", () => {
+    const session = {
+      user: {
+        id: "user_123",
+      },
+    };
+
+    expect(getSessionUserId(session)).toBe("user_123");
+  });
+
+  it("falls back to session.userId when user object is missing", () => {
+    const session = {
+      session: {
+        userId: "user_456",
+      },
+    };
+
+    expect(getSessionUserId(session)).toBe("user_456");
+  });
+
+  it("returns null when no user id is available", () => {
+    expect(getSessionUserId({ user: {} })).toBeNull();
+    expect(getSessionUserId(null)).toBeNull();
+  });
+});

--- a/src/lib/auth/session-utils.ts
+++ b/src/lib/auth/session-utils.ts
@@ -1,0 +1,21 @@
+export function getSessionUserId(
+  session:
+    | {
+        user?: { id?: string | null } | null;
+        session?: { userId?: string | null } | null;
+      }
+    | null
+    | undefined,
+): string | null {
+  const directUserId = session?.user?.id;
+  if (typeof directUserId === "string" && directUserId.length > 0) {
+    return directUserId;
+  }
+
+  const fallbackUserId = session?.session?.userId;
+  if (typeof fallbackUserId === "string" && fallbackUserId.length > 0) {
+    return fallbackUserId;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Prevent onboarding crashes when Better Auth session payloads do not include `session.user.id`
- Add a shared `getSessionUserId` helper that resolves from either `session.user.id` or `session.session.userId`
- Normalize validated sessions in API route helpers so downstream handlers can safely rely on `session.user.id`
- Update onboarding page and onboarding profile GET/PUT routes to use resolved user id consistently
- Add focused tests for user-id fallback behavior

## Why this approach
- The production error (`Cannot read properties of undefined (reading 'id')`) indicated brittle assumptions around session shape
- This fix addresses the root cause by centralizing safe user-id extraction and making auth validation return a normalized session object

## Verification
- `bun run check`
- `bun run test:run src/lib/auth/__tests__/session-utils.test.ts`
- `bun run build`
- Pre-push hook also passed full unit suite: `vitest run` (39 files, 725 tests)