### PR TITLE
fix(api): handle static route context and add client debug logs

### DIFF
--- a/src/app/clients/page.tsx
+++ b/src/app/clients/page.tsx
@@ -87,8 +87,35 @@ export default function ClientsPage() {
         setIsLoading(true);
         setError(null);
 
-        const response = await fetch("/api/clients", {
+        const requestUrl = "/api/clients";
+        const requestMethod = "GET";
+
+        console.debug("[clients-page] Request", {
+          url: requestUrl,
+          method: requestMethod,
+        });
+
+        const response = await fetch(requestUrl, {
+          method: requestMethod,
+          headers: {
+            Accept: "application/json",
+          },
           credentials: "include",
+        });
+
+        const responseText = await response.text();
+        let responseBody: unknown = responseText;
+        try {
+          responseBody = responseText ? JSON.parse(responseText) : null;
+        } catch {
+          // Keep raw text if response is not JSON
+        }
+
+        console.debug("[clients-page] Response", {
+          url: requestUrl,
+          method: requestMethod,
+          status: response.status,
+          body: responseBody,
         });
 
         if (!response.ok) {
@@ -104,15 +131,30 @@ export default function ClientsPage() {
               "Server error. Please try again later or contact support.",
             );
           }
-          const errorData = await response.json().catch(() => ({}));
+          const errorData =
+            typeof responseBody === "object" && responseBody !== null
+              ? (responseBody as Record<string, unknown>)
+              : {};
+          const errorMessageFromBody =
+            typeof errorData.error === "string" ? errorData.error : undefined;
           throw new Error(
-            errorData.error || `Failed to fetch clients (${response.status})`,
+            errorMessageFromBody ||
+              `Failed to fetch clients (${response.status})`,
           );
         }
 
-        const data = await response.json();
-        setClients(data.clients || []);
+        const data =
+          typeof responseBody === "object" && responseBody !== null
+            ? (responseBody as Record<string, unknown>)
+            : {};
+        setClients(
+          Array.isArray(data.clients) ? (data.clients as Client[]) : [],
+        );
       } catch (err) {
+        console.error("[clients-page] fetchClients failed", {
+          message: err instanceof Error ? err.message : String(err),
+          stack: err instanceof Error ? err.stack : undefined,
+        });
         const errorMessage =
           err instanceof Error ? err.message : "An unexpected error occurred";
         setError(errorMessage);

--- a/src/lib/api/__tests__/route-helpers.test.ts
+++ b/src/lib/api/__tests__/route-helpers.test.ts
@@ -68,4 +68,23 @@ describe("withApiHandler advisor guard", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
   });
+
+  it("handles static routes when Next omits route context", async () => {
+    mockGetSession.mockResolvedValue({ user: { id: "user-1" } });
+    mockFindFirst.mockResolvedValue({ accountType: "advisor" });
+
+    const handler = withApiHandler(
+      {
+        endpoint: "/api/test",
+        method: "GET",
+        requireAdvisor: true,
+      },
+      async () => ({ data: { ok: true } }),
+    );
+
+    const response = await handler(new Request("http://localhost/api/test"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
 });

--- a/src/lib/api/route-helpers.ts
+++ b/src/lib/api/route-helpers.ts
@@ -70,9 +70,11 @@ type ApiHandler = (
 export function withApiHandler(config: ApiHandlerConfig, handler: ApiHandler) {
   return async (
     request: Request,
-    { params }: { params: Promise<Record<string, string>> },
+    context?: {
+      params?: Promise<Record<string, string>> | Record<string, string>;
+    },
   ): Promise<NextResponse> => {
-    const resolvedParams = await params;
+    const resolvedParams = await Promise.resolve(context?.params ?? {});
     const clientId = resolvedParams.id;
 
     // Build endpoint string with actual IDs for logging
@@ -87,6 +89,11 @@ export function withApiHandler(config: ApiHandlerConfig, handler: ApiHandler) {
     });
 
     try {
+      await logger.info("API request received", {
+        requestUrl: request.url,
+        requestMethod: request.method,
+      });
+
       // Validate session
       const sessionResult = config.requireAdvisor
         ? await validateAdvisorSession(logger)
@@ -149,8 +156,17 @@ export function withApiHandler(config: ApiHandlerConfig, handler: ApiHandler) {
 
       // Return NextResponse directly or wrap data
       if (result instanceof NextResponse) {
+        await logger.info("API response returned", {
+          statusCode: result.status,
+          responseBody: await readResponseBodyForDebug(result),
+        });
         return result;
       }
+
+      await logger.info("API response returned", {
+        statusCode: result.status ?? 200,
+        responseBody: result.data,
+      });
 
       return NextResponse.json(result.data, { status: result.status ?? 200 });
     } catch (error) {
@@ -164,6 +180,20 @@ export function withApiHandler(config: ApiHandlerConfig, handler: ApiHandler) {
       );
     }
   };
+}
+
+async function readResponseBodyForDebug(response: NextResponse) {
+  try {
+    const text = await response.clone().text();
+    if (!text) return null;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  } catch {
+    return "Unable to read response body";
+  }
 }
 
 /**


### PR DESCRIPTION
# Fix: Clients page failing to load (Server Error)

## Summary
This PR resolves an issue where the `/clients` page displayed:

"Unable to load clients"
"Server error. Please try again later or contact support."

The clients list failed to render due to a server-side error in the fetching flow.

---

## Root Cause
The clients fetch request was failing in the server/API handler layer.  
The real error was being swallowed by generic error handling, making debugging difficult and always returning a generic UI error message.

---

## Changes Made

### Traced Fetch Flow
- Located the component rendering the error state
- Traced the request from UI → fetch layer → API route → database
- Verified authentication and request handling

### Improved Logging
- Added targeted logging in the server handler
- Ensured real error stack traces are visible in server logs
- Preserved friendly UI error messaging

### Fixed Underlying Issue
- Corrected the server-side failure in the clients fetching flow
- Ensured valid client data is returned for authenticated users

---

## Result
- `/clients` now loads correctly
- Client data renders as expected
- Errors are properly logged for debugging
- No UI regressions

---

## Testing
- Verified clients load successfully for authenticated users
- Confirmed no console errors
- Tested failure scenario to validate error handling

---
Closes #254 