### PR TITLE
Canada-first consumer flow cleanup + plain-language copy rewrite (#291, #292)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "insurflow",

--- a/docs/canada-first-consumer-copy-notes.md
+++ b/docs/canada-first-consumer-copy-notes.md
@@ -1,0 +1,23 @@
+# Canada-First Consumer Copy Cleanup Notes
+
+Updated for issues #291 and #292.
+
+## Remaining US-Specific Behavior (Intentional MVP Exception)
+
+- The demo estimate screen still renders `RateTableDisplay` using
+  `getStateRateTable(...)` from `src/lib/transparency/rate-tables.ts`.
+- That reference table contains US-oriented tax and probate labels/data.
+
+## Why This Is Retained In This Pass
+
+- This change set is intentionally scoped to consumer-facing UI copy and wording
+  updates.
+- Replacing the underlying transparency dataset is a separate data/modeling task
+  and was kept out of scope to avoid broad non-copy changes.
+
+## Follow-Up Direction
+
+- Replace demo transparency table data with a Canada-specific dataset in a
+  dedicated follow-up task.
+- Keep the current non-binding estimate disclaimers and methodology visibility
+  behavior unchanged during that migration.

--- a/src/app/__tests__/home-d2c-cta.test.tsx
+++ b/src/app/__tests__/home-d2c-cta.test.tsx
@@ -21,7 +21,7 @@ vi.mock("next/image", () => ({
 
 import { AuthStatus } from "@/components/auth-status";
 
-describe("Home page D2C CTA", () => {
+describe("Home page primary CTA", () => {
   it("renders primary signed-out CTA linking to sign-up with client role", () => {
     render(<AuthStatus />);
 

--- a/src/app/apply/estimate/page.test.tsx
+++ b/src/app/apply/estimate/page.test.tsx
@@ -40,7 +40,7 @@ describe("ApplyEstimatePage", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", { name: /non-binding estimate preview/i }),
+        screen.getByRole("heading", { name: /estimate preview/i }),
       ).toBeTruthy();
     });
 

--- a/src/app/apply/estimate/page.tsx
+++ b/src/app/apply/estimate/page.tsx
@@ -192,11 +192,11 @@ export default function ApplyEstimatePage() {
             Step 2 of 4
           </p>
           <h1 className="font-display text-foreground text-3xl tracking-tight sm:text-4xl">
-            Your non-binding estimate preview
+            Your estimate preview
           </h1>
           <p className="text-muted-foreground max-w-2xl text-sm sm:text-base">
-            This estimate is based on your intake details for {intake.province}.
-            It is not an offer, quote, or policy approval.
+            This non-binding estimate is based on your intake details for{" "}
+            {intake.province}. It is not an offer, quote, or policy approval.
           </p>
         </section>
 
@@ -215,7 +215,7 @@ export default function ApplyEstimatePage() {
 
           <Card className="border-border/60 bg-card/80 p-6">
             <p className="text-muted-foreground text-sm">
-              Estimated monthly range
+              Estimated monthly cost range
             </p>
             <p className="text-foreground mt-2 text-3xl font-semibold">
               {formatCurrency(premiumLow)} - {formatCurrency(premiumHigh)}
@@ -228,9 +228,9 @@ export default function ApplyEstimatePage() {
         </section>
 
         <Card className="border-amber-300/40 bg-amber-50/40 p-4 text-sm leading-relaxed">
-          This is a conservative, non-binding estimate preview only. Final
-          premium, eligibility, and coverage depend on full underwriting,
-          disclosures, and carrier review.
+          This is a conservative, non-binding estimate only. Final premium,
+          eligibility, and coverage depend on full underwriting, disclosures,
+          and carrier review.
         </Card>
 
         <div className="flex justify-end">

--- a/src/app/apply/intake/page.tsx
+++ b/src/app/apply/intake/page.tsx
@@ -86,11 +86,11 @@ export default function D2cIntakePage() {
           </div>
 
           <h1 className="font-display text-foreground text-2xl font-semibold tracking-tight lg:text-3xl">
-            Let&apos;s get started
+            Let&apos;s get your estimate started
           </h1>
           <p className="text-muted-foreground mt-2 max-w-2xl">
-            Share a few details to see a conservative, non-binding estimate
-            preview before starting your application.
+            Share a few details to see a non-binding estimate preview before
+            continuing your application.
           </p>
         </div>
 
@@ -105,10 +105,10 @@ export default function D2cIntakePage() {
             >
               <div className="space-y-1">
                 <p className="text-foreground text-sm font-semibold">
-                  Basic Information
+                  Your details
                 </p>
                 <p className="text-muted-foreground text-xs">
-                  All fields are required for eligibility assessment.
+                  These fields are required to generate your estimate preview.
                 </p>
               </div>
 
@@ -155,7 +155,7 @@ export default function D2cIntakePage() {
                   </span>
                 </Label>
                 <p className="text-muted-foreground text-xs">
-                  Your age affects premium rates. Must be 18-70 years old.
+                  Your age affects premium rates. You must be 18-70 years old.
                 </p>
                 <Input
                   id="date-of-birth"
@@ -311,7 +311,7 @@ export default function D2cIntakePage() {
                   className="bg-emerald hover:bg-emerald/90 gap-2"
                   disabled={!isFormValid}
                 >
-                  Continue to Estimate
+                  Continue to estimate
                   <ArrowRight className="h-4 w-4" />
                 </Button>
               </div>
@@ -371,7 +371,7 @@ export default function D2cIntakePage() {
               </p>
               <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
                 We use bank-level encryption to protect your data. Your
-                information is used only to generate your estimate preview and
+                information is only used to generate your estimate preview and
                 application details.
               </p>
             </Card>

--- a/src/app/apply/review/review-form.tsx
+++ b/src/app/apply/review/review-form.tsx
@@ -47,18 +47,18 @@ export default function ReviewForm({ clientId }: ReviewFormProps) {
             Step 3 of 4
           </p>
           <h1 className="font-display text-foreground text-3xl tracking-tight sm:text-4xl">
-            Review &amp; Consent
+            Review and consent
           </h1>
           <p className="text-muted-foreground text-sm sm:text-base">
-            Review your application details and accept the required disclosures
-            before proceeding.
+            Review your details and accept the required disclosures before
+            submitting.
           </p>
         </section>
 
         {/* Application summary */}
         <Card className="border-border/60 bg-card/80 p-6">
           <h2 className="mb-4 text-sm font-semibold tracking-wide uppercase">
-            Your application details
+            Your details
           </h2>
           <div className="grid gap-4 sm:grid-cols-2">
             <p className="text-sm">

--- a/src/app/apply/submit/page.tsx
+++ b/src/app/apply/submit/page.tsx
@@ -18,7 +18,7 @@ export default async function ApplySubmitPage() {
             Application submitted
           </h1>
           <p className="text-muted-foreground text-sm sm:text-base">
-            Your application has been received. We will be in touch.
+            Thanks, your application has been received. We will be in touch.
           </p>
         </section>
 

--- a/src/app/auth/[path]/page.tsx
+++ b/src/app/auth/[path]/page.tsx
@@ -20,21 +20,20 @@ export function generateStaticParams() {
 const features = [
   {
     icon: Clock,
-    title: "Fast Eligibility Check",
+    title: "Quick Eligibility Check",
     description:
-      "Complete a short intake and see your estimate preview in minutes",
+      "Answer a few questions and see your estimate preview in minutes",
   },
   {
     icon: FileText,
-    title: "Simple Application Flow",
+    title: "Simple Application Steps",
     description:
-      "Move from estimate to application submission in one guided journey",
+      "Move from estimate to submission in one clear, guided journey",
   },
   {
     icon: BarChart3,
-    title: "Clear Status Tracking",
-    description:
-      "Track your application with clear, easy-to-understand status updates",
+    title: "Clear Status Updates",
+    description: "Track your application with clear updates at each step",
   },
   {
     icon: Smartphone,
@@ -45,7 +44,7 @@ const features = [
 
 const stats = [
   { value: "5 min", label: "Typical Intake" },
-  { value: "D2C", label: "Consumer-first" },
+  { value: "Plain", label: "Clear language" },
   { value: "Live", label: "Status Timeline" },
 ];
 
@@ -124,7 +123,7 @@ export default async function AuthPage({
               </div>
             </div>
             <p className="max-w-md text-base leading-relaxed font-medium text-white/90 lg:text-lg">
-              Check your term life coverage needs and submit an application in{" "}
+              Check your term life coverage needs and submit your application in{" "}
               <span className="text-emerald-400">under 5 minutes</span>.
             </p>
           </div>
@@ -145,12 +144,12 @@ export default async function AuthPage({
           <div className="hidden space-y-4 lg:block">
             <h2 className="flex items-center gap-2 text-lg font-semibold text-white">
               <Shield className="text-emerald h-5 w-5" />
-              Built for Canada-first D2C Term Life
+              Built for Canada-first term life applications
             </h2>
             <p className="max-w-md leading-relaxed text-white/80">
               Start with a short eligibility check, review a non-binding
-              estimate, and submit your application. You can track each update
-              in one place.
+              estimate, and submit your application with clear updates in one
+              place.
             </p>
           </div>
 
@@ -199,7 +198,7 @@ export default async function AuthPage({
             </h2>
             <p className="text-muted-foreground mt-2 text-sm">
               {isSignUp
-                ? "Start with a short profile setup for personalized guidance"
+                ? "Set up your profile in minutes to personalize your experience"
                 : "Sign in to continue to InsurFlow"}
             </p>
           </div>

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -11,7 +11,7 @@ describe("DashboardPage", () => {
     const accountType = normalizeAccountType(undefined) ?? "client";
     const experience = getDashboardExperience(accountType);
 
-    expect(experience.heading).toMatch(/continue your application/i);
+    expect(experience.heading).toMatch(/keep going with your application/i);
     expect(experience.cards[0]?.href).toBe("/apply/review");
   });
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -218,7 +218,7 @@ export default async function DashboardPage() {
             <Card className="border-border/60 bg-card/80 shadow-sm backdrop-blur-sm">
               <CardHeader className="space-y-2">
                 <p className="text-emerald text-xs font-semibold tracking-wide uppercase">
-                  Draft in progress
+                  Application in progress
                 </p>
                 <CardTitle className="text-xl">
                   Resume your application
@@ -250,7 +250,7 @@ export default async function DashboardPage() {
                     <Link
                       href={`${APPLY_INTAKE_ROUTE}?clientId=${encodeURIComponent(draftClient.id)}`}
                     >
-                      Continue Application
+                      Continue application
                       <ArrowRight className="ml-2 h-4 w-4" />
                     </Link>
                   </Button>

--- a/src/app/demo/estimate/page.tsx
+++ b/src/app/demo/estimate/page.tsx
@@ -55,11 +55,11 @@ export default function DemoEstimatePage() {
             className="font-display text-foreground text-2xl font-semibold tracking-tight lg:text-3xl"
             data-tour="estimate-heading"
           >
-            Your estimated coverage need
+            Your coverage estimate
           </h1>
           <p className="text-muted-foreground mt-2 max-w-2xl">
-            This snapshot uses your intake answers to provide a first estimate.
-            Your advisor will validate every number with you.
+            This snapshot uses your intake answers to provide a first,
+            non-binding estimate.
           </p>
         </div>
 
@@ -68,11 +68,10 @@ export default function DemoEstimatePage() {
           data-tour="assumptions-controls"
         >
           <h2 className="text-foreground text-lg font-semibold">
-            Adjust assumptions live
+            Try different assumptions
           </h2>
           <p className="text-muted-foreground mt-1 text-sm">
-            In guided mode, you can quickly test sensitivity before showing
-            advisor-ready outputs.
+            Move the sliders to see how your estimate changes.
           </p>
           <div className="mt-4 grid gap-4 md:grid-cols-3">
             <label className="space-y-2 text-sm">
@@ -178,18 +177,16 @@ export default function DemoEstimatePage() {
               Why this matters
             </h3>
             <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-              This gives your advisor a clear starting point so your review can
-              focus on practical choices, affordability, and protection goals
-              that fit your family.
+              This gives you a clear starting point so you can compare options
+              based on affordability and protection goals.
             </p>
           </Card>
         </div>
 
         <Card className="mt-6 border-amber-300/40 bg-amber-50/40 p-4">
           <p className="text-sm leading-relaxed">
-            This is an estimate, not final advice. A licensed advisor must
-            review your full financial details before any recommendation is
-            finalized.
+            This is a non-binding estimate, not a quote or final advice. Final
+            recommendations require a full review of your details.
           </p>
         </Card>
 
@@ -223,7 +220,7 @@ export default function DemoEstimatePage() {
             onClick={() => router.push("/demo/showcase")}
             className="bg-emerald hover:bg-emerald/90 gap-2"
           >
-            Continue to AI and Report Showcase
+            Continue to explanation and report
             <ArrowRight className="h-4 w-4" />
           </Button>
         </div>

--- a/src/app/demo/handoff/page.tsx
+++ b/src/app/demo/handoff/page.tsx
@@ -47,11 +47,11 @@ export default function DemoHandoffPage() {
           </div>
 
           <h1 className="font-display text-foreground text-2xl font-semibold tracking-tight lg:text-3xl">
-            Review your estimate with an advisor
+            Next steps after your estimate
           </h1>
           <p className="text-muted-foreground mt-2 max-w-2xl">
-            You are at the final step. A human advisor helps validate your
-            estimate and make sure the recommendation fits real-life goals.
+            You are at the final step. A licensed advisor can help validate your
+            estimate and tailor final recommendations to your goals.
           </p>
         </div>
 
@@ -83,18 +83,18 @@ export default function DemoHandoffPage() {
             variant="outline"
             className="border-emerald/30 bg-emerald/10 text-emerald"
           >
-            Advisor view note
+            Demo summary
           </Badge>
           <p className="mt-2 text-sm leading-relaxed">
-            Your intake, interactive estimate, AI draft letter, and report
-            preview are ready for advisor follow-up.
+            Your intake, estimate, AI explanation, and report preview are ready
+            for a follow-up conversation.
           </p>
         </Card>
 
         <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
           <Button asChild className="bg-emerald hover:bg-emerald/90 gap-2">
             <Link href="/auth/sign-up">
-              Connect with an Advisor
+              Connect with an advisor
               <ArrowRight className="h-4 w-4" />
             </Link>
           </Button>

--- a/src/app/demo/intake/page.tsx
+++ b/src/app/demo/intake/page.tsx
@@ -88,7 +88,7 @@ export default function DemoIntakePage() {
           </h1>
           <p className="text-muted-foreground mt-2 max-w-2xl">
             Answer two quick questions to get a first estimate. You can add more
-            details if you want a tighter result.
+            details if you want a more tailored result.
           </p>
         </div>
 
@@ -251,7 +251,7 @@ export default function DemoIntakePage() {
                   type="submit"
                   className="bg-emerald hover:bg-emerald/90 gap-2"
                 >
-                  See Estimate now
+                  See estimate now
                   <ArrowRight className="h-4 w-4" />
                 </Button>
               </div>
@@ -304,7 +304,7 @@ export default function DemoIntakePage() {
                 </li>
                 <li className="flex items-start gap-2">
                   <FileText className="mt-0.5 h-3.5 w-3.5" />
-                  AI letter and report preview for advisor follow-up
+                  AI explanation and report preview
                 </li>
               </ul>
             </Card>

--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -55,11 +55,11 @@ export default function DemoPage() {
         {/* Hero Section */}
         <div className="animate-fade-up mx-auto max-w-3xl text-center">
           <h1 className="font-display text-foreground mb-4 text-4xl font-semibold tracking-tight lg:text-5xl">
-            Experience the Client Journey
+            Try the application experience
           </h1>
           <p className="text-muted-foreground mx-auto max-w-2xl text-base leading-relaxed sm:text-lg">
-            Configure one realistic scenario, run the intake in minutes, and
-            jump straight into advisor-ready analysis output.
+            Pick a realistic scenario, run a short intake, and see an estimate
+            walkthrough in minutes.
           </p>
 
           <div className="mx-auto mt-6 mb-2 flex w-fit rounded-full border p-1">
@@ -92,11 +92,11 @@ export default function DemoPage() {
           <Card className="border-border/60 bg-card/50 p-5 sm:p-6">
             <div className="mb-4">
               <h2 className="text-foreground text-xl font-semibold">
-                Choose a planning scenario
+                Choose a scenario
               </h2>
               <p className="text-muted-foreground mt-1 text-sm">
-                Pick one path to pre-load context and make the walkthrough feel
-                like a real advisor session.
+                Pick one path to preload details and make the walkthrough feel
+                realistic.
               </p>
             </div>
 
@@ -201,7 +201,7 @@ export default function DemoPage() {
                   {state.demoMode === "guided"
                     ? "Expect 8-10 minutes."
                     : "Expect 3-4 minutes."}{" "}
-                  No sign-up required.
+                  No sign-up needed.
                 </p>
               </div>
             </Card>
@@ -212,8 +212,8 @@ export default function DemoPage() {
               </p>
               <ul className="text-muted-foreground mt-2 space-y-2 text-sm">
                 <li>- Structured intake with scenario context</li>
-                <li>- Live estimate adjustments before advisor review</li>
-                <li>- AI letter and client-report handoff preview</li>
+                <li>- Live estimate adjustments and clear assumptions</li>
+                <li>- AI explanation and report preview</li>
               </ul>
             </Card>
           </div>

--- a/src/app/demo/showcase/page.tsx
+++ b/src/app/demo/showcase/page.tsx
@@ -43,11 +43,11 @@ export default function DemoShowcasePage() {
           </div>
 
           <h1 className="font-display text-foreground text-2xl font-semibold tracking-tight lg:text-3xl">
-            Turn calculations into advisor-ready deliverables
+            See your explanation and report preview
           </h1>
           <p className="text-muted-foreground mt-2 max-w-2xl">
-            This guided showcase demonstrates how one analysis becomes a
-            compliance-ready narrative and a client-facing report.
+            This walkthrough shows how your estimate can be turned into a clear
+            explanation and a shareable report summary.
           </p>
         </div>
 
@@ -60,7 +60,7 @@ export default function DemoShowcasePage() {
               </h2>
             </div>
             <p className="text-muted-foreground mt-2 text-sm">
-              Auto-generated explanation using the selected assumptions and
+              Auto-generated explanation based on your selected assumptions and
               intake profile.
             </p>
             <div className="bg-muted/40 mt-4 max-h-[280px] overflow-y-auto rounded-lg p-4 text-sm leading-relaxed">
@@ -83,8 +83,8 @@ export default function DemoShowcasePage() {
               </h2>
             </div>
             <p className="text-muted-foreground mt-2 text-sm">
-              Export-ready summary advisors can review before meeting the
-              client.
+              Export-ready summary you can review before speaking with an
+              advisor.
             </p>
             <div className="mt-4 grid gap-3">
               <div className="bg-muted/40 rounded-lg p-4">
@@ -121,7 +121,7 @@ export default function DemoShowcasePage() {
             onClick={() => router.push("/demo/handoff")}
             className="bg-emerald hover:bg-emerald/90 gap-2"
           >
-            Continue to Advisor Handoff
+            Continue to next steps
             <ArrowRight className="h-4 w-4" />
           </Button>
         </div>

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -55,12 +55,11 @@ export default async function OnboardingPage({
             Welcome to InsurFlow
           </p>
           <h1 className="font-display text-foreground text-4xl tracking-tight">
-            Let&apos;s personalize your planning workspace
+            Let&apos;s set up your account
           </h1>
           <p className="text-muted-foreground mx-auto max-w-2xl text-sm sm:text-base">
-            We are shifting to a client-first experience. Tell us a little about
-            your household and goals so your dashboard and recommendations are
-            tailored from day one.
+            Share a few details about your household and goals so your dashboard
+            and application steps feel tailored from day one.
           </p>
         </div>
 

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -27,19 +27,19 @@ vi.mock("next/link", () => ({
   ),
 }));
 
-describe("Home page D2C direction", () => {
+describe("Home page consumer direction", () => {
   it("uses consumer-first journey language", () => {
     render(<Home />);
 
     expect(
       screen.getByRole("heading", {
-        name: /your path to a term life application/i,
+        name: /your path to term life coverage/i,
       }),
     ).toBeTruthy();
-    expect(screen.getAllByText(/eligibility intake/i).length).toBeGreaterThan(
-      0,
-    );
-    expect(screen.getByText(/application status tracking/i)).toBeTruthy();
+    expect(screen.getAllByText(/eligibility check/i).length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(/with clear status updates after submission/i),
+    ).toBeTruthy();
     expect(screen.queryByText(/advisor handoff/i)).toBeNull();
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,50 +23,50 @@ import { Button } from "@/components/ui/button";
 const features = [
   {
     icon: Clock,
-    title: "Fast Eligibility Intake",
+    title: "Quick Eligibility Check",
     description:
-      "Complete a short intake and move straight into a clear, non-binding estimate.",
+      "Answer a few questions and move straight into a clear, non-binding estimate.",
     stat: "5 min",
     statLabel: "Typical intake",
   },
   {
     icon: Calculator,
-    title: "Clear Estimate Preview",
+    title: "Easy Estimate Preview",
     description:
-      "Understand your estimated coverage range, assumptions, and what affects the result.",
-    stat: "D2C",
-    statLabel: "Consumer-first",
+      "See your estimated coverage range, what it means, and what can affect it.",
+    stat: "Plain",
+    statLabel: "Clear language",
   },
   {
     icon: FileText,
-    title: "Guided Application",
+    title: "Simple Application Steps",
     description:
-      "Move from estimate to application submission with a simple review and consent step.",
+      "Move from estimate to submission with a guided review and consent step.",
     stat: "1 flow",
     statLabel: "Estimate to submit",
   },
   {
     icon: Sparkles,
-    title: "Live Status Timeline",
+    title: "Live Status Updates",
     description:
-      "Track your application from received to review updates with clear status events.",
+      "Track your application from received to reviewed with clear status updates.",
     stat: "Live",
     statLabel: "Status tracking",
   },
 ];
 
 const painPoints = [
-  "Long, confusing insurance research before you can apply",
-  "Unclear estimate language that sounds like a guaranteed quote",
+  "Too much research before you can even start",
+  "Estimate wording that feels confusing or too technical",
   "Disconnected steps between estimate and application",
-  "No simple way to track what happens after you submit",
+  "No clear view of what happens after you submit",
 ];
 
 const solutions = [
-  "A short, guided intake built for first-time applicants",
-  "Conservative non-binding estimate language you can understand",
-  "One D2C flow from eligibility to application submission",
-  "Transparent provider status updates in your account",
+  "A short guided intake built for first-time applicants",
+  "Non-binding estimate language in plain terms",
+  "One clear flow from eligibility to submission",
+  "Transparent status updates in your account",
 ];
 
 const applicationFlowSteps = [
@@ -123,10 +123,10 @@ export default function Home() {
 
           {/* Headline */}
           <h1 className="animate-fade-up animation-delay-100 text-foreground font-display mb-6 text-4xl font-normal tracking-tight sm:text-5xl md:text-6xl lg:text-7xl">
-            Your path to a{" "}
+            Your path to{" "}
             <span className="relative">
               <span className="from-primary to-emerald relative z-10 bg-gradient-to-r via-[oklch(0.55_0.12_200)] bg-clip-text text-transparent">
-                term life application
+                term life coverage
               </span>
               <span className="bg-emerald/20 absolute right-0 -bottom-1 left-0 h-3 -skew-x-6" />
             </span>
@@ -134,12 +134,12 @@ export default function Home() {
 
           {/* Subheadline */}
           <p className="animate-fade-up animation-delay-200 text-muted-foreground mb-8 max-w-2xl text-lg sm:text-xl">
-            InsurFlow helps you complete eligibility intake, review a
-            non-binding estimate, and submit your application in{" "}
+            InsurFlow helps you answer a few questions, review a non-binding
+            estimate, and submit your application in{" "}
             <span className="text-foreground font-semibold">
               under 5 minutes
             </span>{" "}
-            with transparent application status tracking after submission.
+            with clear status updates after submission.
           </p>
 
           {/* CTA Buttons */}
@@ -315,11 +315,11 @@ export default function Home() {
               Platform Capabilities
             </Badge>
             <h2 className="animate-fade-up text-foreground font-display text-3xl font-normal tracking-tight sm:text-4xl">
-              Everything you need for D2C term life intake and submission
+              Everything you need to apply with confidence
             </h2>
             <p className="animate-fade-up animation-delay-100 text-muted-foreground mx-auto mt-4 max-w-2xl">
-              From eligibility intake to application status updates, InsurFlow
-              keeps the process clear, fast, and consumer-friendly.
+              From eligibility to submission, InsurFlow keeps the process clear,
+              fast, and easy to follow.
             </p>
           </div>
 
@@ -379,7 +379,7 @@ export default function Home() {
 
           <p className="animate-fade-up animation-delay-200 text-muted-foreground mx-auto mt-4 max-w-xl text-lg">
             Start with a short eligibility check, review your estimate, and
-            continue to account-gated application submission.
+            continue to a simple, guided submission flow.
           </p>
 
           <div className="animate-fade-up animation-delay-300 mt-8 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">

--- a/src/components/demo/tour-steps.ts
+++ b/src/components/demo/tour-steps.ts
@@ -26,14 +26,14 @@ function createTourSteps(inputs: TourStepInput[]): TourStep[] {
 export const demoIntakeTourSteps: TourStep[] = createTourSteps([
   [
     "[data-tour='intake-heading']",
-    "Capture Core Inputs",
-    "This section captures household and financial context to drive a first-pass recommendation.",
+    "Start with the basics",
+    "This section captures the key household details needed for a first estimate.",
     "bottom",
   ],
   [
     "[data-tour='intake-form']",
-    "Structured Intake",
-    "The guided form keeps data entry lightweight while still collecting enough signal for meaningful analysis.",
+    "Guided form",
+    "The form keeps questions short while collecting enough detail for a useful estimate.",
     "bottom",
   ],
 ]);
@@ -41,32 +41,32 @@ export const demoIntakeTourSteps: TourStep[] = createTourSteps([
 export const demoEstimateTourSteps: TourStep[] = createTourSteps([
   [
     "[data-tour='estimate-heading']",
-    "Interactive Estimate",
-    "This recommendation responds immediately to assumption changes so advisors can model scenarios live.",
+    "Interactive estimate",
+    "Your estimate updates as assumptions change so you can quickly compare outcomes.",
     "bottom",
   ],
   [
     "[data-tour='assumptions-controls']",
-    "Assumption Controls",
-    "Adjust income replacement, duration, and liquid asset offsets to pressure-test outcomes.",
+    "Assumption controls",
+    "Adjust income replacement, duration, and liquid asset offsets to test different outcomes.",
     "bottom",
   ],
   [
     "[data-tour='estimate-kpis']",
-    "Coverage Snapshot",
-    "Recommended coverage and coverage gap are presented side by side for clear conversation framing.",
+    "Coverage snapshot",
+    "Recommended coverage and coverage gap are shown side by side for easy comparison.",
     "top",
   ],
   [
     "[data-tour='estimate-transparency']",
-    "Calculation Transparency",
-    "Open this section to show the exact methodology and state-specific reference tables behind the estimate.",
+    "Calculation transparency",
+    "Open this section to review the methodology and reference tables used for this demo estimate.",
     "top",
   ],
   [
     "[data-tour='showcase-next']",
-    "Continue to Showcase",
-    "Next you will see AI and report deliverables generated from this analysis.",
+    "Continue",
+    "Next you will see the AI explanation and report preview for this estimate.",
     "top",
     "Click to continue",
   ],
@@ -75,20 +75,20 @@ export const demoEstimateTourSteps: TourStep[] = createTourSteps([
 export const demoShowcaseTourSteps: TourStep[] = createTourSteps([
   [
     "[data-tour='ai-letter-preview']",
-    "AI Narrative Output",
-    "The letter preview turns the numbers into recommendation reasoning advisors can refine before delivery.",
+    "AI explanation",
+    "The letter preview turns estimate numbers into clear plain-language reasoning.",
     "bottom",
   ],
   [
     "[data-tour='report-preview']",
-    "Client Report Preview",
-    "The report card condenses assumptions and recommendation values into an advisor-ready summary.",
+    "Report preview",
+    "The report card summarizes assumptions and recommendation values in one place.",
     "bottom",
   ],
   [
     "[data-tour='showcase-handoff']",
-    "Advisor Handoff",
-    "Continue with confidence: both analysis and communication artifacts are now ready.",
+    "Next steps",
+    "Continue when you are ready to review what happens after this estimate.",
     "top",
     "Click to continue",
   ],

--- a/src/components/onboarding/onboarding-form.test.tsx
+++ b/src/components/onboarding/onboarding-form.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { OnboardingForm } from "./onboarding-form";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe("OnboardingForm location selector", () => {
+  it("shows Province/Territory label with Canadian options only", () => {
+    render(
+      <OnboardingForm
+        initialProfile={{
+          firstName: "Ari",
+          lastName: "North",
+          state: "ON",
+        }}
+      />,
+    );
+
+    expect(screen.getByLabelText(/province\/territory/i)).toBeTruthy();
+    expect(
+      screen.getByRole("option", {
+        name: /select your province or territory/i,
+      }),
+    ).toBeTruthy();
+    expect(screen.getByRole("option", { name: /ontario/i })).toBeTruthy();
+    expect(screen.getByRole("option", { name: /quebec/i })).toBeTruthy();
+    expect(screen.queryByRole("option", { name: /alabama/i })).toBeNull();
+    expect(screen.queryByRole("option", { name: /california/i })).toBeNull();
+  });
+});

--- a/src/components/onboarding/onboarding-form.tsx
+++ b/src/components/onboarding/onboarding-form.tsx
@@ -13,9 +13,9 @@ import {
   type OnboardingProfileInput,
 } from "@/lib/onboarding";
 import { AUTHENTICATED_HOME_ROUTE } from "@/lib/app-routes";
+import { CANADIAN_PROVINCE_TERRITORY_OPTIONS } from "@/lib/constants";
 import { getAccountTypeConfirmation } from "@/lib/role-experience";
 import { cn } from "@/lib/utils";
-import { STATES } from "@/lib/validation/client";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -75,7 +75,7 @@ export function OnboardingForm({ initialProfile }: OnboardingFormProps) {
         throw new Error(payload?.error ?? "Unable to save onboarding details");
       }
 
-      toast.success("Profile completed. Welcome to InsurFlow.");
+      toast.success("Profile saved. Welcome to InsurFlow.");
       router.replace(AUTHENTICATED_HOME_ROUTE);
       router.refresh();
     } catch (error) {
@@ -93,10 +93,10 @@ export function OnboardingForm({ initialProfile }: OnboardingFormProps) {
     <Card className="border-border/60 shadow-sm">
       <CardHeader>
         <CardTitle className="font-display text-2xl">
-          Complete your profile
+          Tell us a few basics
         </CardTitle>
         <p className="text-muted-foreground text-sm">
-          This helps us tailor your insurance guidance and planning experience.
+          This helps us personalize your estimate and application journey.
         </p>
       </CardHeader>
 
@@ -132,7 +132,7 @@ export function OnboardingForm({ initialProfile }: OnboardingFormProps) {
 
           <div className="space-y-2">
             <label className="text-sm font-medium" htmlFor="state">
-              State
+              Province/Territory
             </label>
             <select
               id="state"
@@ -141,10 +141,10 @@ export function OnboardingForm({ initialProfile }: OnboardingFormProps) {
               className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
               required
             >
-              <option value="">Select your state</option>
-              {STATES.map((stateCode) => (
-                <option key={stateCode} value={stateCode}>
-                  {stateCode}
+              <option value="">Select your province or territory</option>
+              {CANADIAN_PROVINCE_TERRITORY_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
                 </option>
               ))}
             </select>
@@ -275,7 +275,7 @@ export function OnboardingForm({ initialProfile }: OnboardingFormProps) {
 
           <Button type="submit" disabled={isSubmitting} className="w-full">
             <CheckCircle2 className="mr-2 h-4 w-4" />
-            {isSubmitting ? "Saving your profile..." : "Finish onboarding"}
+            {isSubmitting ? "Saving your profile..." : "Save and continue"}
           </Button>
         </form>
       </CardContent>

--- a/src/lib/__tests__/role-experience.test.ts
+++ b/src/lib/__tests__/role-experience.test.ts
@@ -46,7 +46,9 @@ describe("role experience helpers", () => {
     const clientExperience = getDashboardExperience("client");
 
     expect(advisorExperience.heading).toMatch(/advisor workspace/i);
-    expect(clientExperience.heading).toMatch(/continue your application/i);
+    expect(clientExperience.heading).toMatch(
+      /keep going with your application/i,
+    );
     expect(advisorExperience.cards[0]?.title).not.toBe(
       clientExperience.cards[0]?.title,
     );
@@ -73,7 +75,7 @@ describe("role experience helpers", () => {
       /client account selected/i,
     );
     expect(getAccountTypeConfirmation("client")?.description).toMatch(
-      /application-focused dashboard/i,
+      /application dashboard/i,
     );
     expect(getAccountTypeConfirmation("")).toBeNull();
   });

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -219,6 +219,30 @@ export const STATE_OPTIONS = STATES.map((code) => ({
   label: STATE_LABELS[code] ?? code,
 }));
 
+/** Canadian provinces and territories for Canada-first consumer onboarding UI */
+export const CANADIAN_PROVINCE_TERRITORY_CODES = [
+  "AB",
+  "BC",
+  "MB",
+  "NB",
+  "NL",
+  "NS",
+  "NT",
+  "NU",
+  "ON",
+  "PE",
+  "QC",
+  "SK",
+  "YT",
+] as const;
+
+/** Province/territory dropdown options for Canada-first UI flows */
+export const CANADIAN_PROVINCE_TERRITORY_OPTIONS =
+  CANADIAN_PROVINCE_TERRITORY_CODES.map((code) => ({
+    value: code,
+    label: STATE_LABELS[code] ?? code,
+  }));
+
 /**
  * Get display label for state code
  */

--- a/src/lib/role-experience.ts
+++ b/src/lib/role-experience.ts
@@ -93,32 +93,29 @@ export function getDashboardExperience(
 
   return {
     eyebrow: "My Application",
-    heading: "Track and continue your application",
+    heading: "Keep going with your application",
     description:
-      "Resume your intake, review your estimate preview, and submit your application when you are ready.",
+      "Pick up where you left off, review your estimate, and submit when you are ready.",
     cards: [
       {
-        title: "Continue Application",
-        description:
-          "Pick up where you left off and review the latest application details.",
+        title: "Continue your application",
+        description: "Return to your latest draft and keep moving forward.",
         href: APPLY_REVIEW_ROUTE,
-        ctaLabel: "Open Review",
+        ctaLabel: "Open review",
         icon: "clipboard",
       },
       {
-        title: "Update Estimate",
-        description:
-          "Adjust your intake details and refresh your estimate preview.",
+        title: "Update your estimate",
+        description: "Change your details and refresh your estimate preview.",
         href: APPLY_ESTIMATE_ROUTE,
-        ctaLabel: "View Estimate",
+        ctaLabel: "View estimate",
         icon: "chart",
       },
       {
-        title: "Start New Intake",
-        description:
-          "Start over with a new intake if your household details changed.",
+        title: "Start a new application",
+        description: "Start over if your household details have changed.",
         href: APPLY_INTAKE_ROUTE,
-        ctaLabel: "Start Intake",
+        ctaLabel: "Start intake",
         icon: "handoff",
       },
     ],
@@ -143,7 +140,7 @@ export function getAccountTypeConfirmation(
     return {
       title: "Client account selected",
       description:
-        "You will see an application-focused dashboard with intake, estimate preview, and submission guidance.",
+        "You will see an application dashboard with intake, estimate, and submission guidance.",
       tone: "client",
     };
   }


### PR DESCRIPTION
## Summary
This PR delivers a Canada-first, plain-language consumer copy cleanup for MVP issues #291 and #292.

It is intentionally scoped to UI/copy behavior only: no backend behavior changes, no API contract changes, no schema changes, and no route/path changes.

## What Changed
- Rewrote consumer-facing copy in plain language across:
  - homepage (`/`)
  - auth pages (`/auth/sign-up`, `/auth/sign-in`)
  - onboarding page + form (`/onboarding`)
  - client dashboard experience (`/dashboard`, client-only copy)
  - apply flow top-level pages (`/apply/intake`, `/apply/estimate`, `/apply/review`, `/apply/submit`)
  - demo flow surfaces (`/demo`, `/demo/intake`, `/demo/estimate`, `/demo/showcase`, `/demo/handoff`) and guided tour text.
- Removed user-visible `D2C` jargon and simplified technical phrasing.
- Updated onboarding location UX to Canada-first:
  - `State` -> `Province/Territory`
  - dropdown now uses Canadian province/territory options only in onboarding UI
  - payload contract remains unchanged (`state` key still used).
- Added a focused onboarding form test to assert province/territory labeling and Canadian-only options.
- Updated existing copy assertions in affected tests.

## Intentional Exception (Documented)
- `/demo/estimate` still renders the US-oriented transparency rate table (`getStateRateTable(...)`) as an MVP exception.
- Rationale and follow-up are documented in:
  - `docs/canada-first-consumer-copy-notes.md`

## Why This Approach
- Keeps risk low by limiting scope to content/UI surfaces.
- Preserves existing contracts and runtime behavior.
- Delivers immediate Canada-first clarity improvements without broad data-model refactors.

## Verification
- Pre-push checks ran successfully:
  - `eslint && tsc --noEmit`
  - `vitest run`
- Result: all test files and tests passed during pre-push gate (`72 files`, `1058 tests`).

## Follow-Up
- Replace demo transparency table data with Canada-specific reference data in a dedicated follow-up task.

Closes #291
Closes #292
