### PR TITLE
feat: add advisor carrier comparison API contract

### DIFF
--- a/docs/advisor-carrier-shopping-workflow.md
+++ b/docs/advisor-carrier-shopping-workflow.md
@@ -1,0 +1,130 @@
+# Advisor Carrier-Shopping Workflow (MVP)
+
+## Objective
+
+Define one implementation-ready advisor-assisted workflow for partner-carrier shopping that:
+
+- Keeps the current D2C submission + status flow intact.
+- Adds a licensed-advisor recommendation step where it creates near-term GTM value.
+- Clearly separates MVP scope from post-MVP expansion.
+
+## Decision Summary
+
+Recommended MVP posture: advisor-assisted lane is additive, not a replacement for self-serve D2C.
+
+- Client still owns account creation, consent, and final application submission.
+- Advisor owns comparison, recommendation rationale, and handoff guidance.
+- Submission and status tracking reuse existing provider and application pipelines.
+
+## Actor Responsibilities
+
+### Client
+
+- Complete intake and fact-finding data.
+- Review advisor recommendation and disclosures.
+- Confirm handoff and complete consent.
+- Submit application and track status.
+
+### Advisor (licensed)
+
+- Review intake completeness for quote shopping.
+- Trigger carrier comparison using normalized inputs.
+- Record recommendation plus rationale.
+- Provide handoff context and next-step guidance.
+
+### System
+
+- Normalize comparison inputs and return provider-agnostic option summaries.
+- Enforce ownership, auth, and workflow transitions.
+- Preserve auditability (best-effort, PII-safe).
+- Keep provider integration behind carrier abstraction.
+
+## End-to-End Workflow
+
+1. Client completes intake (`/apply/intake`) and optional fact-finding.
+2. Advisor opens client context in advisor workspace.
+3. Advisor requests comparison; system returns normalized carrier option set.
+4. Advisor records one recommendation and rationale.
+5. Client sees recommendation + disclosures and acknowledges handoff.
+6. Client completes consent and submits application (existing submit flow).
+7. Client tracks status timeline (existing application status flow).
+
+## Minimal Data Requirements (MVP)
+
+For comparison:
+
+- Province
+- Date of birth (or derived age)
+- Tobacco use
+- Coverage amount
+- Term years
+
+For recommendation/handoff:
+
+- Selected provider key
+- Recommendation rationale (plain text, bounded length)
+- Advisor identifier
+- Recommendation timestamp
+
+For submission continuity:
+
+- Existing consent timestamps
+- Client ownership and active status checks
+
+## API Implications (MVP)
+
+- Add advisor comparison endpoint for normalized quote-shopping request/response.
+- Add recommendation capture endpoint with strict validation.
+- Add client handoff acknowledgement endpoint that gates transition to submit-ready.
+- Reuse existing submission and status endpoints; do not fork carrier submission logic.
+
+Implementation constraints:
+
+- Use `withApiHandler(...)` for route consistency.
+- Reuse shared ownership and UUID validation helpers.
+- Keep audit logging best-effort and sanitized.
+
+## UI Implications (MVP)
+
+- Add advisor view for carrier comparison + recommendation capture.
+- Add client review block showing recommendation summary and handoff acknowledgement.
+- Keep non-binding language explicit on all comparison/recommendation displays.
+- Do not add policy purchase or issuance screens.
+
+## Compliance and Licensing Touchpoints
+
+- Advisor lane assumes licensed professional involvement for recommendation step.
+- Province handling remains Canada-first.
+- Recommendation and handoff actions should be auditable without raw sensitive data.
+- Disclosure/legal copy requires product/legal review before launch.
+
+## In Scope (MVP)
+
+- One canonical advisor-assisted workflow.
+- One normalized comparison contract.
+- Recommendation + handoff data capture.
+- Explicit boundaries and follow-up build tickets.
+
+## Out of Scope (MVP)
+
+- Carrier-specific underwriting APIs and purchase flows.
+- Payments, binding, issuance, policy servicing.
+- Real-time production multi-carrier integrations.
+- Advanced advisor analytics dashboards.
+
+## Follow-up Implementation Tickets
+
+1. API: Advisor carrier comparison contract and normalized response shape.
+2. API: Recommendation capture + client handoff acknowledgement transitions.
+3. UI: Advisor carrier-shopping workspace shell.
+4. Compliance/Audit: Advisor workflow lifecycle events, PII-safe.
+5. Product/Compliance: Disclosure and licensing review checklist for advisor lane.
+
+## Acceptance Criteria Mapping (Issue #293)
+
+- End-to-end workflow documented: yes.
+- Actor responsibilities defined: yes.
+- Minimal data for comparison/submission defined: yes.
+- API/UI implications listed: yes.
+- MVP in-scope vs out-of-scope explicit: yes.
+- Compliance/licensing touchpoints called out: yes.

--- a/docs/plans/2026-03-12-advisor-carrier-shopping-workflow-design.md
+++ b/docs/plans/2026-03-12-advisor-carrier-shopping-workflow-design.md
@@ -1,0 +1,483 @@
+# Advisor Carrier-Shopping Workflow Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Define and validate one MVP advisor carrier-shopping workflow (intake -> compare options -> recommend -> submit/handoff), with explicit scope boundaries and implementation-ready follow-up tickets.
+
+**Architecture:** Keep the current D2C submission path intact and layer an advisor-assisted lane around existing client/application primitives. Reuse current ownership/auth patterns and carrier abstraction points; do not introduce carrier-specific behavior into MVP core routes. Capture workflow logic as a deterministic state contract first, then map APIs/UI to that contract.
+
+**Tech Stack:** Next.js App Router, TypeScript strict mode, Drizzle ORM/PostgreSQL, Better Auth, Vitest, GitHub CLI (`gh`).
+
+---
+
+## Scope Guardrails
+
+- In scope for this plan:
+  - A single approved advisor-assisted MVP workflow spec.
+  - Data contract and responsibilities for advisor vs client.
+  - Follow-up engineering tasks with exact files and test commands.
+- Out of scope for this plan:
+  - Carrier-specific underwriting/purchase/issuance logic.
+  - Payments/billing.
+  - Real-time multi-carrier production integrations.
+
+## Assumptions To Preserve
+
+- D2C v1 stop line remains submission + status tracking.
+- `CarrierProvider` remains minimal and provider-agnostic.
+- Existing D2C routes stay valid for consumer self-serve path.
+- Compliance review gates are required before advisor workflow goes live.
+
+## Workflow Contract (Target)
+
+1. Client intake captured (existing D2C intake fields).
+2. Advisor opens client profile and requests carrier comparison.
+3. System returns normalized option cards (premium range + caveats).
+4. Advisor records recommendation with rationale.
+5. Client reviews recommendation and confirms handoff.
+6. Submission uses existing provider submission pipeline.
+7. Status tracking remains existing application timeline.
+
+---
+
+### Task 1: Write the canonical workflow spec artifact
+
+**Files:**
+
+- Create: `docs/advisor-carrier-shopping-workflow.md`
+- Reference: `docs/product-direction-alignment.md`
+- Reference: `README.md`
+
+**Step 1: Write the failing test**
+
+Create a checklist in `docs/advisor-carrier-shopping-workflow.md` with unchecked required sections:
+
+- Objective
+- Actor responsibility matrix
+- End-to-end sequence
+- MVP in-scope/out-of-scope
+- Compliance/licensing checkpoints
+- API and UI implications
+
+**Step 2: Run test to verify it fails**
+
+Run: `grep -n "\[x\]" docs/advisor-carrier-shopping-workflow.md`
+Expected: no completed checklist items.
+
+**Step 3: Write minimal implementation**
+
+Fill the workflow doc with:
+
+- One canonical sequence diagram (textual).
+- Advisor/client responsibility matrix.
+- Explicit stop line preserving D2C constraints.
+
+**Step 4: Run test to verify it passes**
+
+Run: `grep -n "## Objective\|## Actor Responsibilities\|## End-to-End Workflow\|## In Scope\|## Out of Scope\|## Compliance Touchpoints\|## API Implications\|## UI Implications" docs/advisor-carrier-shopping-workflow.md`
+Expected: all required sections present.
+
+**Step 5: Commit**
+
+```bash
+git add docs/advisor-carrier-shopping-workflow.md
+git commit -m "docs: define mvp advisor carrier-shopping workflow"
+```
+
+---
+
+### Task 2: Add deterministic workflow state contract (pure logic)
+
+**Files:**
+
+- Create: `src/lib/workflows/advisor-shopping-workflow.ts`
+- Create: `src/lib/workflows/__tests__/advisor-shopping-workflow.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  ADVISOR_SHOPPING_STATES,
+  canTransition,
+} from "@/lib/workflows/advisor-shopping-workflow";
+
+describe("advisor shopping workflow transitions", () => {
+  it("allows compare -> recommended", () => {
+    expect(canTransition("comparison_ready", "recommended")).toBe(true);
+  });
+
+  it("blocks intake -> submitted", () => {
+    expect(canTransition("intake_ready", "submitted")).toBe(false);
+  });
+
+  it("exports stable state list", () => {
+    expect(ADVISOR_SHOPPING_STATES).toContain("handoff_confirmed");
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun run test:run src/lib/workflows/__tests__/advisor-shopping-workflow.test.ts`
+Expected: FAIL with module not found.
+
+**Step 3: Write minimal implementation**
+
+```ts
+export const ADVISOR_SHOPPING_STATES = [
+  "intake_ready",
+  "comparison_requested",
+  "comparison_ready",
+  "recommended",
+  "handoff_confirmed",
+  "submitted",
+] as const;
+
+export type AdvisorShoppingState = (typeof ADVISOR_SHOPPING_STATES)[number];
+
+const ALLOWED_TRANSITIONS: Record<
+  AdvisorShoppingState,
+  AdvisorShoppingState[]
+> = {
+  intake_ready: ["comparison_requested"],
+  comparison_requested: ["comparison_ready"],
+  comparison_ready: ["recommended"],
+  recommended: ["handoff_confirmed"],
+  handoff_confirmed: ["submitted"],
+  submitted: [],
+};
+
+export function canTransition(
+  from: AdvisorShoppingState,
+  to: AdvisorShoppingState,
+) {
+  return ALLOWED_TRANSITIONS[from].includes(to);
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `bun run test:run src/lib/workflows/__tests__/advisor-shopping-workflow.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/lib/workflows/advisor-shopping-workflow.ts src/lib/workflows/__tests__/advisor-shopping-workflow.test.ts
+git commit -m "feat: add deterministic advisor workflow state contract"
+```
+
+---
+
+### Task 3: Define advisor comparison API contract (no carrier lock-in)
+
+**Files:**
+
+- Create: `src/lib/api/advisor-comparison-helpers.ts`
+- Create: `src/lib/api/__tests__/advisor-comparison-helpers.test.ts`
+- Create: `src/app/api/advisor/clients/[clientId]/carrier-comparison/route.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { buildComparisonRequest } from "@/lib/api/advisor-comparison-helpers";
+
+describe("buildComparisonRequest", () => {
+  it("maps minimum intake fields only", () => {
+    const result = buildComparisonRequest({
+      province: "ON",
+      dateOfBirth: "1990-01-01",
+      tobaccoUse: false,
+      coverageAmount: "500000",
+      termYears: 20,
+    });
+
+    expect(result).toEqual({
+      province: "ON",
+      age: 36,
+      tobaccoUse: false,
+      coverageAmount: 500000,
+      termYears: 20,
+    });
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun run test:run src/lib/api/__tests__/advisor-comparison-helpers.test.ts`
+Expected: FAIL with missing helper.
+
+**Step 3: Write minimal implementation**
+
+- Implement pure mapping and validation helper.
+- Route uses `withApiHandler(...)`, UUID validation, and ownership checks.
+- Route returns normalized comparison payload only (no submit side effects).
+
+**Step 4: Run test to verify it passes**
+
+Run: `bun run test:run src/lib/api/__tests__/advisor-comparison-helpers.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/lib/api/advisor-comparison-helpers.ts src/lib/api/__tests__/advisor-comparison-helpers.test.ts src/app/api/advisor/clients/[clientId]/carrier-comparison/route.ts
+git commit -m "feat: add advisor carrier comparison contract"
+```
+
+---
+
+### Task 4: Add recommendation capture + handoff acknowledgement APIs
+
+**Files:**
+
+- Create: `src/app/api/advisor/clients/[clientId]/recommendation/route.ts`
+- Create: `src/app/api/d2c/handoff/[clientId]/acknowledge/route.ts`
+- Create: `src/lib/api/advisor-recommendation-helpers.ts`
+- Create: `src/lib/api/__tests__/advisor-recommendation-helpers.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { recommendationSchema } from "@/lib/api/advisor-recommendation-helpers";
+
+describe("recommendation schema", () => {
+  it("requires rationale and selected provider", () => {
+    const parsed = recommendationSchema.safeParse({
+      providerKey: "mock",
+      rationale: "Best fit for client profile",
+    });
+    expect(parsed.success).toBe(true);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun run test:run src/lib/api/__tests__/advisor-recommendation-helpers.test.ts`
+Expected: FAIL with missing exports.
+
+**Step 3: Write minimal implementation**
+
+- Add schema + sanitizer for recommendation text.
+- Persist recommendation metadata in workflow-safe storage (or temporary JSON metadata table).
+- Add client acknowledgement endpoint that only transitions recommended -> handoff_confirmed.
+
+**Step 4: Run test to verify it passes**
+
+Run: `bun run test:run src/lib/api/__tests__/advisor-recommendation-helpers.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/app/api/advisor/clients/[clientId]/recommendation/route.ts src/app/api/d2c/handoff/[clientId]/acknowledge/route.ts src/lib/api/advisor-recommendation-helpers.ts src/lib/api/__tests__/advisor-recommendation-helpers.test.ts
+git commit -m "feat: add advisor recommendation and handoff acknowledgement endpoints"
+```
+
+---
+
+### Task 5: Add advisor UI workflow shell
+
+**Files:**
+
+- Create: `src/app/advisor/clients/[clientId]/carrier-shopping/page.tsx`
+- Create: `src/app/advisor/clients/[clientId]/carrier-shopping/page.test.tsx`
+- Create: `src/components/advisor/carrier-option-card.tsx`
+
+**Step 1: Write the failing test**
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import CarrierShoppingPage from "@/app/advisor/clients/[clientId]/carrier-shopping/page";
+
+describe("CarrierShoppingPage", () => {
+  it("shows comparison and recommendation actions", async () => {
+    render(
+      await CarrierShoppingPage({ params: { clientId: "test" } } as never),
+    );
+    expect(screen.getByText(/carrier comparison/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /save recommendation/i }),
+    ).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun run test:run src/app/advisor/clients/[clientId]/carrier-shopping/page.test.tsx`
+Expected: FAIL with missing page.
+
+**Step 3: Write minimal implementation**
+
+- Render comparison summary list and provider option cards.
+- Add recommendation save CTA and handoff CTA.
+- Keep copy explicit that estimates are non-binding.
+
+**Step 4: Run test to verify it passes**
+
+Run: `bun run test:run src/app/advisor/clients/[clientId]/carrier-shopping/page.test.tsx`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/app/advisor/clients/[clientId]/carrier-shopping/page.tsx src/app/advisor/clients/[clientId]/carrier-shopping/page.test.tsx src/components/advisor/carrier-option-card.tsx
+git commit -m "feat: add advisor carrier-shopping workflow shell"
+```
+
+---
+
+### Task 6: Add compliance and audit event hooks (best-effort)
+
+**Files:**
+
+- Modify: `src/lib/api/audit-helpers.ts`
+- Create: `src/lib/api/__tests__/advisor-audit-events.test.ts`
+- Modify: `src/app/api/advisor/clients/[clientId]/recommendation/route.ts`
+- Modify: `src/app/api/d2c/handoff/[clientId]/acknowledge/route.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { sanitizeAuditPayload } from "@/lib/api/audit-helpers";
+
+describe("advisor audit sanitization", () => {
+  it("redacts token and secret-like fields", () => {
+    const payload = sanitizeAuditPayload({
+      recommendation: "text",
+      token: "abc",
+      secret: "xyz",
+    });
+    expect(payload).toMatchObject({
+      recommendation: "text",
+      token: "[REDACTED]",
+      secret: "[REDACTED]",
+    });
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun run test:run src/lib/api/__tests__/advisor-audit-events.test.ts`
+Expected: FAIL until advisor event coverage is added.
+
+**Step 3: Write minimal implementation**
+
+- Emit best-effort audit events for:
+  - comparison requested
+  - recommendation saved
+  - handoff acknowledged
+- Ensure raw sensitive values are not logged.
+
+**Step 4: Run test to verify it passes**
+
+Run: `bun run test:run src/lib/api/__tests__/advisor-audit-events.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/lib/api/audit-helpers.ts src/lib/api/__tests__/advisor-audit-events.test.ts src/app/api/advisor/clients/[clientId]/recommendation/route.ts src/app/api/d2c/handoff/[clientId]/acknowledge/route.ts
+git commit -m "feat: add pii-safe advisor workflow audit events"
+```
+
+---
+
+### Task 7: End-to-end verification for touched surfaces
+
+**Files:**
+
+- Verify: all files touched in Tasks 2-6
+
+**Step 1: Write the failing test**
+
+Record expected verification matrix in PR notes:
+
+- API/auth/data mutations: lint + typecheck + module tests.
+- UI workflow page tests.
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun run check`
+Expected: FAIL initially until all tasks complete.
+
+**Step 3: Write minimal implementation**
+
+Address lint/type errors and flaky tests without broad refactors.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+- `bun run check`
+- `bun run test:run src/lib/workflows/__tests__/advisor-shopping-workflow.test.ts src/lib/api/__tests__/advisor-comparison-helpers.test.ts src/lib/api/__tests__/advisor-recommendation-helpers.test.ts src/lib/api/__tests__/advisor-audit-events.test.ts src/app/advisor/clients/[clientId]/carrier-shopping/page.test.tsx`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "test: verify advisor carrier-shopping workflow surfaces"
+```
+
+---
+
+### Task 8: Create follow-up GitHub tickets linked to #293
+
+**Files:**
+
+- Modify: GitHub issue tracker (no repo file)
+
+**Step 1: Write the failing test**
+
+Draft ticket titles in a local checklist and mark all unchecked.
+
+**Step 2: Run test to verify it fails**
+
+Run: `gh issue list --search "linked:293 advisor carrier"`
+Expected: no linked follow-up issues yet.
+
+**Step 3: Write minimal implementation**
+
+Create at least four linked tickets:
+
+1. API comparison contract
+2. Recommendation + handoff endpoints
+3. Advisor UI shell
+4. Compliance + audit coverage
+
+**Step 4: Run test to verify it passes**
+
+Run: `gh issue view 293`
+Expected: issue body/comments reference created follow-up tickets.
+
+**Step 5: Commit**
+
+No git commit required for tracker-only updates.
+
+---
+
+## Failure Modes and Guardrails
+
+- Risk: advisor workflow scope conflicts with D2C self-serve assumptions.
+  - Guardrail: keep advisor lane additive; do not remove self-serve submit path.
+- Risk: accidental carrier-specific lock-in.
+  - Guardrail: enforce normalized comparison contracts and provider-agnostic keys.
+- Risk: compliance drift from informal recommendation text.
+  - Guardrail: require rationale schema + disclosure copy + audit trail.
+
+## Definition of Done
+
+- Workflow spec approved with one canonical sequence.
+- In-scope/out-of-scope boundaries are explicit and enforced in tickets.
+- Follow-up tasks are implementation-ready with exact files/tests.
+- Verification matrix is executable and green before merge.

--- a/src/app/api/advisor/clients/[clientId]/carrier-comparison/__tests__/route.test.ts
+++ b/src/app/api/advisor/clients/[clientId]/carrier-comparison/__tests__/route.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createMockSession,
+  TEST_UUIDS,
+} from "@/lib/api/__tests__/helpers/d2c-resume-link-test-helpers";
+
+const mockGetSession = vi.fn();
+const mockProfileFindFirst = vi.fn();
+const mockFindAdvisorCarrierComparison = vi.fn();
+
+vi.mock("@/server/better-auth/server", () => ({
+  getSession: () => mockGetSession(),
+}));
+
+vi.mock("@/server/db", () => ({
+  getDb: vi.fn(() => ({
+    query: {
+      userProfile: {
+        findFirst: mockProfileFindFirst,
+      },
+    },
+  })),
+}));
+
+vi.mock("@/server/axiom", () => ({
+  createLogger: vi.fn(() => ({
+    addContext: vi.fn(),
+    info: vi.fn(async () => undefined),
+    warn: vi.fn(async () => undefined),
+    error: vi.fn(async () => undefined),
+  })),
+}));
+
+vi.mock("@/lib/api/advisor-comparison-helpers", () => ({
+  findAdvisorCarrierComparison: (...args: unknown[]) =>
+    mockFindAdvisorCarrierComparison(...args),
+}));
+
+async function getComparison(clientId: string) {
+  const { GET } = await import("../route");
+  return GET(
+    new Request(
+      `http://localhost/api/advisor/clients/${clientId}/carrier-comparison`,
+      { method: "GET" },
+    ),
+    { params: Promise.resolve({ clientId }) },
+  );
+}
+
+describe("GET /api/advisor/clients/[clientId]/carrier-comparison", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(createMockSession(TEST_UUIDS.validUserId));
+    mockProfileFindFirst.mockResolvedValue({ accountType: "advisor" });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const response = await getComparison(TEST_UUIDS.validClientId);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 403 for non-advisor accounts", async () => {
+    mockProfileFindFirst.mockResolvedValue({ accountType: "client" });
+
+    const response = await getComparison(TEST_UUIDS.validClientId);
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 400 for invalid client ID", async () => {
+    const response = await getComparison("not-a-uuid");
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 404 when client is not found", async () => {
+    mockFindAdvisorCarrierComparison.mockResolvedValue({ found: false });
+
+    const response = await getComparison(TEST_UUIDS.validClientId);
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 422 when comparison data is incomplete", async () => {
+    mockFindAdvisorCarrierComparison.mockResolvedValue({
+      found: true,
+      ready: false,
+      missingFields: ["coverageAmount"],
+    });
+
+    const response = await getComparison(TEST_UUIDS.validClientId);
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.missingFields).toEqual(["coverageAmount"]);
+  });
+
+  it("returns 200 with comparison payload", async () => {
+    mockFindAdvisorCarrierComparison.mockResolvedValue({
+      found: true,
+      ready: true,
+      request: {
+        province: "ON",
+        age: 36,
+        tobaccoUse: false,
+        coverageAmount: 500000,
+        termYears: 20,
+      },
+      options: [
+        {
+          providerKey: "mock",
+          premiumRange: {
+            lowMonthlyPremiumCad: 44,
+            highMonthlyPremiumCad: 66,
+            currency: "CAD",
+            nonBinding: true,
+          },
+        },
+      ],
+    });
+
+    const response = await getComparison(TEST_UUIDS.validClientId);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.request.province).toBe("ON");
+    expect(body.options).toHaveLength(1);
+    expect(mockFindAdvisorCarrierComparison).toHaveBeenCalledWith(
+      TEST_UUIDS.validClientId,
+      TEST_UUIDS.validUserId,
+    );
+  });
+});

--- a/src/app/api/advisor/clients/[clientId]/carrier-comparison/route.ts
+++ b/src/app/api/advisor/clients/[clientId]/carrier-comparison/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+
+import { findAdvisorCarrierComparison } from "@/lib/api/advisor-comparison-helpers";
+import { validateUUID } from "@/lib/api/client-helpers";
+import { withApiHandler } from "@/lib/api/route-helpers";
+
+export const GET = withApiHandler(
+  {
+    endpoint: "/api/advisor/clients/[clientId]/carrier-comparison",
+    method: "GET",
+    requireAdvisor: true,
+  },
+  async (_request, { logger, session, params }) => {
+    const clientId = params.clientId ?? "";
+    const clientIdError = validateUUID(clientId, "client ID");
+
+    if (clientIdError) {
+      await logger.warn("Invalid client ID format", { clientId });
+      return clientIdError;
+    }
+
+    const result = await findAdvisorCarrierComparison(
+      clientId,
+      session.user.id,
+    );
+
+    if (!result.found) {
+      await logger.info("Client not found for advisor comparison", {
+        statusCode: 404,
+        clientId,
+      });
+      return NextResponse.json({ error: "Client not found" }, { status: 404 });
+    }
+
+    if (!result.ready) {
+      await logger.info("Comparison request missing required fields", {
+        statusCode: 422,
+        clientId,
+        missingFields: result.missingFields,
+      });
+      return NextResponse.json(
+        {
+          error: "Missing required fields for carrier comparison",
+          missingFields: result.missingFields,
+        },
+        { status: 422 },
+      );
+    }
+
+    await logger.info("Advisor carrier comparison generated", {
+      statusCode: 200,
+      clientId,
+      optionCount: result.options.length,
+    });
+
+    return {
+      data: {
+        request: result.request,
+        options: result.options,
+      },
+    };
+  },
+);

--- a/src/lib/api/__tests__/advisor-comparison-helpers.test.ts
+++ b/src/lib/api/__tests__/advisor-comparison-helpers.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TEST_UUIDS } from "./helpers/d2c-resume-link-test-helpers";
+import { findAdvisorCarrierComparison } from "../advisor-comparison-helpers";
+
+const mockClientFindFirst = vi.fn();
+const mockListProviderIds = vi.fn();
+const mockGetCarrierProvider = vi.fn();
+const mockEstimateRange = vi.fn();
+
+vi.mock("@/server/db", () => ({
+  getDb: vi.fn(() => ({
+    query: {
+      client: {
+        findFirst: mockClientFindFirst,
+      },
+    },
+  })),
+}));
+
+vi.mock("@/lib/providers/carrier-registry", () => ({
+  listProviderIds: () => mockListProviderIds(),
+  getCarrierProvider: (...args: unknown[]) => mockGetCarrierProvider(...args),
+}));
+
+function createClientRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    id: TEST_UUIDS.validClientId,
+    state: "ON",
+    dateOfBirth: "1990-01-01",
+    smoker: false,
+    existingLifeInsuranceCoverage: "500000.00",
+    replacementDurationYears: 20,
+    ...overrides,
+  };
+}
+
+describe("findAdvisorCarrierComparison", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListProviderIds.mockReturnValue(["mock"]);
+    mockEstimateRange.mockResolvedValue({
+      lowMonthlyPremiumCad: 44,
+      highMonthlyPremiumCad: 66,
+      currency: "CAD",
+      nonBinding: true,
+    });
+    mockGetCarrierProvider.mockReturnValue({
+      providerId: "mock",
+      getEstimateRange: mockEstimateRange,
+    });
+  });
+
+  it("returns found false when client is missing", async () => {
+    mockClientFindFirst.mockResolvedValue(null);
+
+    const result = await findAdvisorCarrierComparison(
+      TEST_UUIDS.validClientId,
+      TEST_UUIDS.validUserId,
+      new Date("2026-03-12T00:00:00Z"),
+    );
+
+    expect(result).toEqual({ found: false });
+  });
+
+  it("returns not-ready when required comparison fields are missing", async () => {
+    mockClientFindFirst.mockResolvedValue(
+      createClientRecord({ existingLifeInsuranceCoverage: "0" }),
+    );
+
+    const result = await findAdvisorCarrierComparison(
+      TEST_UUIDS.validClientId,
+      TEST_UUIDS.validUserId,
+      new Date("2026-03-12T00:00:00Z"),
+    );
+
+    expect(result.found).toBe(true);
+    if (result.found) {
+      expect(result.ready).toBe(false);
+      if (!result.ready) {
+        expect(result.missingFields).toContain("coverageAmount");
+      }
+    }
+  });
+
+  it("returns normalized request and provider options", async () => {
+    mockClientFindFirst.mockResolvedValue(createClientRecord());
+
+    const result = await findAdvisorCarrierComparison(
+      TEST_UUIDS.validClientId,
+      TEST_UUIDS.validUserId,
+      new Date("2026-03-12T00:00:00Z"),
+    );
+
+    expect(result.found).toBe(true);
+    if (result.found && result.ready) {
+      expect(result.request).toEqual({
+        province: "ON",
+        age: 36,
+        tobaccoUse: false,
+        coverageAmount: 500000,
+        termYears: 20,
+      });
+      expect(result.options).toEqual([
+        {
+          providerKey: "mock",
+          premiumRange: {
+            lowMonthlyPremiumCad: 44,
+            highMonthlyPremiumCad: 66,
+            currency: "CAD",
+            nonBinding: true,
+          },
+        },
+      ]);
+    }
+
+    expect(mockEstimateRange).toHaveBeenCalledWith({
+      province: "ON",
+      age: 36,
+      tobaccoUse: false,
+      coverageAmount: 500000,
+      termYears: 20,
+    });
+  });
+});

--- a/src/lib/api/advisor-comparison-helpers.ts
+++ b/src/lib/api/advisor-comparison-helpers.ts
@@ -1,0 +1,152 @@
+import { and, eq, isNull } from "drizzle-orm";
+
+import type {
+  EstimateRangeInput,
+  PremiumRangeEstimate,
+} from "@/lib/providers/carrier-provider";
+import {
+  getCarrierProvider,
+  listProviderIds,
+} from "@/lib/providers/carrier-registry";
+import { getDb } from "@/server/db";
+import { client } from "@/server/db/schemas";
+
+type ComparisonClientRow = {
+  id: string;
+  state: string;
+  dateOfBirth: string;
+  smoker: boolean;
+  existingLifeInsuranceCoverage: string;
+  replacementDurationYears: number;
+};
+
+export type ComparisonMissingField =
+  | "province"
+  | "dateOfBirth"
+  | "coverageAmount"
+  | "termYears";
+
+export interface CarrierComparisonOption {
+  providerKey: string;
+  premiumRange: PremiumRangeEstimate;
+}
+
+export type AdvisorCarrierComparisonResult =
+  | { found: false }
+  | {
+      found: true;
+      ready: false;
+      missingFields: ComparisonMissingField[];
+    }
+  | {
+      found: true;
+      ready: true;
+      request: EstimateRangeInput;
+      options: CarrierComparisonOption[];
+    };
+
+export async function findAdvisorCarrierComparison(
+  clientId: string,
+  userId: string,
+  asOfDate = new Date(),
+): Promise<AdvisorCarrierComparisonResult> {
+  const db = getDb();
+
+  const row = (await db.query.client.findFirst({
+    where: and(
+      eq(client.id, clientId),
+      eq(client.userId, userId),
+      isNull(client.deletedAt),
+    ),
+    columns: {
+      id: true,
+      state: true,
+      dateOfBirth: true,
+      smoker: true,
+      existingLifeInsuranceCoverage: true,
+      replacementDurationYears: true,
+    },
+  })) as ComparisonClientRow | null;
+
+  if (!row) {
+    return { found: false };
+  }
+
+  const missingFields = getMissingFields(row);
+  if (missingFields.length > 0) {
+    return {
+      found: true,
+      ready: false,
+      missingFields,
+    };
+  }
+
+  const request: EstimateRangeInput = {
+    province: row.state,
+    age: calculateAge(row.dateOfBirth, asOfDate),
+    tobaccoUse: row.smoker,
+    coverageAmount: Number.parseFloat(row.existingLifeInsuranceCoverage),
+    termYears: row.replacementDurationYears,
+  };
+
+  const options: CarrierComparisonOption[] = [];
+  for (const providerId of listProviderIds()) {
+    const provider = getCarrierProvider(providerId);
+    if (!provider?.getEstimateRange) {
+      continue;
+    }
+
+    const premiumRange = await provider.getEstimateRange(request);
+    options.push({
+      providerKey: provider.providerId,
+      premiumRange,
+    });
+  }
+
+  return {
+    found: true,
+    ready: true,
+    request,
+    options,
+  };
+}
+
+function getMissingFields(row: ComparisonClientRow): ComparisonMissingField[] {
+  const missing: ComparisonMissingField[] = [];
+
+  if (!row.state.trim()) {
+    missing.push("province");
+  }
+
+  if (!row.dateOfBirth.trim() || Number.isNaN(Date.parse(row.dateOfBirth))) {
+    missing.push("dateOfBirth");
+  }
+
+  const coverageAmount = Number.parseFloat(row.existingLifeInsuranceCoverage);
+  if (!Number.isFinite(coverageAmount) || coverageAmount <= 0) {
+    missing.push("coverageAmount");
+  }
+
+  if (
+    !Number.isFinite(row.replacementDurationYears) ||
+    row.replacementDurationYears <= 0
+  ) {
+    missing.push("termYears");
+  }
+
+  return missing;
+}
+
+function calculateAge(dateOfBirth: string, asOfDate: Date): number {
+  const dob = new Date(`${dateOfBirth}T00:00:00.000Z`);
+
+  let age = asOfDate.getUTCFullYear() - dob.getUTCFullYear();
+  const monthDelta = asOfDate.getUTCMonth() - dob.getUTCMonth();
+  const dayDelta = asOfDate.getUTCDate() - dob.getUTCDate();
+
+  if (monthDelta < 0 || (monthDelta === 0 && dayDelta < 0)) {
+    age -= 1;
+  }
+
+  return age;
+}


### PR DESCRIPTION
## Summary
- add a canonical MVP advisor carrier-shopping workflow spec and implementation plan docs to unblock issue #293
- implement `GET /api/advisor/clients/[clientId]/carrier-comparison` with advisor auth, UUID validation, and clear 404/422 handling
- add a provider-agnostic comparison helper and focused tests for helper + route behavior

## Verification
- `bun run test:run src/lib/api/__tests__/advisor-comparison-helpers.test.ts`
- `bun run test:run "src/app/api/advisor/clients/[clientId]/carrier-comparison/__tests__/route.test.ts"`
- `bun run check`

## Related
- Closes #293