### PR TITLE
fix(onboarding): run migrations on production deploy and remove applicant type field

### DIFF
--- a/src/components/onboarding/onboarding-form.test.tsx
+++ b/src/components/onboarding/onboarding-form.test.tsx
@@ -41,7 +41,7 @@ describe("OnboardingForm location selector", () => {
     expect(screen.queryByRole("option", { name: /california/i })).toBeNull();
   });
 
-  it("only offers a consumer account option", () => {
+  it("does not render an applicant type field", () => {
     render(
       <OnboardingForm
         initialProfile={{
@@ -52,8 +52,8 @@ describe("OnboardingForm location selector", () => {
       />,
     );
 
-    expect(screen.getByLabelText(/applicant type/i)).toBeTruthy();
-    expect(screen.getByRole("option", { name: /^applicant$/i })).toBeTruthy();
+    // accountType defaults to "client" server-side; the field is not shown to users
+    expect(screen.queryByLabelText(/applicant type/i)).toBeNull();
     expect(screen.queryByRole("option", { name: /advisor/i })).toBeNull();
     expect(screen.queryByText(/advisor workflow/i)).toBeNull();
   });

--- a/src/components/onboarding/onboarding-form.tsx
+++ b/src/components/onboarding/onboarding-form.tsx
@@ -6,7 +6,6 @@ import { CheckCircle2 } from "lucide-react";
 import { toast } from "sonner";
 
 import {
-  ACCOUNT_TYPE_OPTIONS,
   COMMUNICATION_PREFERENCE_OPTIONS,
   HOUSEHOLD_STATUS_OPTIONS,
   PRIMARY_GOAL_OPTIONS,
@@ -14,8 +13,6 @@ import {
 } from "@/lib/onboarding";
 import { AUTHENTICATED_HOME_ROUTE } from "@/lib/app-routes";
 import { CANADIAN_PROVINCE_TERRITORY_OPTIONS } from "@/lib/constants";
-import { getAccountTypeConfirmation } from "@/lib/role-experience";
-import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -39,19 +36,10 @@ export function OnboardingForm({ initialProfile }: OnboardingFormProps) {
   const [communicationPreference, setCommunicationPreference] = useState<
     OnboardingProfileInput["communicationPreference"] | ""
   >(initialProfile.communicationPreference ?? "");
-  const [accountType, setAccountType] = useState<
-    OnboardingProfileInput["accountType"] | ""
-  >(initialProfile.accountType ?? "");
-  const accountTypeConfirmation = getAccountTypeConfirmation(accountType);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-
-    if (!accountType) {
-      toast.error("Select your applicant type to continue.");
-      return;
-    }
 
     setIsSubmitting(true);
 
@@ -66,7 +54,6 @@ export function OnboardingForm({ initialProfile }: OnboardingFormProps) {
           householdStatus,
           primaryGoal,
           communicationPreference,
-          accountType,
         }),
       });
 
@@ -175,46 +162,6 @@ export function OnboardingForm({ initialProfile }: OnboardingFormProps) {
                   </option>
                 ))}
               </select>
-            </div>
-
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="account-type">
-                Applicant type
-              </label>
-              <select
-                id="account-type"
-                value={accountType}
-                onChange={(event) =>
-                  setAccountType(
-                    event.target.value as
-                      | OnboardingProfileInput["accountType"]
-                      | "",
-                  )
-                }
-                className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                required
-              >
-                <option value="">Select applicant type</option>
-                {ACCOUNT_TYPE_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-              {accountTypeConfirmation ? (
-                <div
-                  className={cn(
-                    "rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-900",
-                  )}
-                >
-                  <p className="font-semibold">
-                    {accountTypeConfirmation.title}
-                  </p>
-                  <p className="mt-1 leading-relaxed">
-                    {accountTypeConfirmation.description}
-                  </p>
-                </div>
-              ) : null}
             </div>
 
             <div className="space-y-2">

--- a/src/lib/__tests__/onboarding.test.ts
+++ b/src/lib/__tests__/onboarding.test.ts
@@ -57,7 +57,9 @@ describe("onboarding helpers", () => {
     expect(isOnboardingProfileComplete(profile)).toBe(false);
   });
 
-  it("requires account type to consider onboarding complete", () => {
+  it("considers onboarding complete without an explicit account type", () => {
+    // accountType is no longer collected from the user; it defaults to "client"
+    // so a profile with all user-supplied fields should be considered complete
     expect(
       isOnboardingProfileComplete({
         firstName: "Ada",
@@ -67,7 +69,7 @@ describe("onboarding helpers", () => {
         primaryGoal: "family_protection",
         communicationPreference: "email",
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("only accepts applicant account type in onboarding schema", () => {

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -58,7 +58,7 @@ export const onboardingProfileSchema = z.object({
     "estate_planning",
   ]),
   communicationPreference: z.enum(["email", "phone", "sms"]),
-  accountType: z.enum(["client"]),
+  accountType: z.enum(["client"]).optional().default("client"),
 });
 
 export type OnboardingProfileInput = z.infer<typeof onboardingProfileSchema>;
@@ -121,7 +121,6 @@ export function isOnboardingProfileComplete(
     profile.state?.trim() &&
     profile.householdStatus &&
     profile.primaryGoal &&
-    profile.communicationPreference &&
-    profile.accountType,
+    profile.communicationPreference,
   );
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "buildCommand": "bun run build:full"
+}


### PR DESCRIPTION
## Summary

- **Root cause of onboarding 500:** Production Vercel builds use `next build` only — no migrations run. Preview deployments auto-migrate their Neon branch, but the production database never received those migrations. Migration `0011_sloppy_jimmy_woo` added Canadian provinces to the `state` Postgres enum; without it, inserting any Canadian province value (e.g. `ON`, `BC`) into `user_profile.state` causes a Postgres enum violation → caught by `dbError` → 500.
- **Fix:** Added `vercel.json` setting `buildCommand` to `bun run build:full` (`drizzle-kit migrate && next build`), so all pending migrations are applied on every production deploy going forward.
- **UX change:** Removed the "Applicant type" field from the onboarding form. `accountType` now defaults to `"client"` via Zod schema, so the API always receives a valid value without user input.

## Files Changed

- `vercel.json` — new file; sets Vercel production build command to `bun run build:full`
- `src/components/onboarding/onboarding-form.tsx` — removed applicant type field, state, validation guard, and related imports
- `src/lib/onboarding.ts` — `accountType` made optional with `.default("client")`; removed `accountType` from `isOnboardingProfileComplete` check
- `src/lib/__tests__/onboarding.test.ts` — updated test to reflect that a profile without an explicit `accountType` is now considered complete

## Verification

- `bun run lint && bun run typecheck` — clean
- `bun run test:run` — 1113/1113 tests passing
- Pre-push hook passed (lint + types + full test suite)

## Notes

- The production DB will receive all pending migrations (`0011` through `0014`) on the first deploy after this PR merges. No manual migration step is needed.
- `accountType` is preserved in the DB schema and API with its default of `"client"`. No data migration required.