### PR TITLE
fix: remove react-dom profiling alias from server webpack config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -81,17 +81,6 @@ const config = {
         "prismjs",
         "@react-email/code-block",
       ];
-
-      // Resolve aliases to reduce bundle size
-      config.resolve = {
-        ...config.resolve,
-        alias: {
-          ...config.resolve?.alias,
-          // Don't bundle React dev tools in production
-          "react-dom$": "react-dom/profiling",
-          "scheduler/tracing": "scheduler/tracing-profiling",
-        },
-      };
     }
 
     return config;


### PR DESCRIPTION
## Summary

- Removes the `react-dom/profiling` and `scheduler/tracing-profiling` webpack aliases from the server bundle config in `next.config.js`
- The profiling build adds instrumentation overhead and is not appropriate for SSR in any environment

## Why this approach

The fix is a straight deletion — no replacement needed. Removing the aliases restores Next.js default behavior (standard `react-dom` production build). The comment claimed this was "not bundling React dev tools in production" but the profiling build does the opposite: it adds profiling hooks.

## Verification

- `pnpm lint` — clean
- `pnpm typecheck` — clean

## Known follow-ups

None. Low-risk revert to framework defaults.

Closes #316