### PR TITLE
perf: reuse cached intl formatters in client-utils

### DIFF
--- a/src/lib/client-utils.ts
+++ b/src/lib/client-utils.ts
@@ -1,3 +1,9 @@
+import {
+  currencyFormatter,
+  dateFormatter,
+  dateTimeFormatter,
+} from "@/lib/constants";
+
 /**
  * Calculate age based on date of birth
  */
@@ -22,23 +28,14 @@ export function calculateAge(dateOfBirth: string): number {
  */
 export function formatDate(dateString: string): string {
   const date = new Date(dateString);
-  return new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  }).format(date);
+  return dateFormatter.format(date);
 }
 
 /**
  * Format number as US currency (USD)
  */
 export function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(amount);
+  return currencyFormatter.format(amount);
 }
 
 /**
@@ -53,13 +50,7 @@ export function parseCurrency(value: string): number {
  */
 export function formatDateTime(dateString: string): string {
   const date = new Date(dateString);
-  return new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(date);
+  return dateTimeFormatter.format(date);
 }
 
 /**

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -14,7 +14,7 @@ export const DEFAULT_LOCALE = "en-US";
 export const DEFAULT_CURRENCY = "USD";
 
 // Pre-configured Intl formatters for performance (created once, reused everywhere)
-const currencyFormatter = new Intl.NumberFormat(DEFAULT_LOCALE, {
+export const currencyFormatter = new Intl.NumberFormat(DEFAULT_LOCALE, {
   style: "currency",
   currency: DEFAULT_CURRENCY,
   minimumFractionDigits: 2,
@@ -28,13 +28,13 @@ const compactCurrencyFormatter = new Intl.NumberFormat(DEFAULT_LOCALE, {
   maximumFractionDigits: 0,
 });
 
-const dateFormatter = new Intl.DateTimeFormat(DEFAULT_LOCALE, {
+export const dateFormatter = new Intl.DateTimeFormat(DEFAULT_LOCALE, {
   year: "numeric",
   month: "short",
   day: "numeric",
 });
 
-const dateTimeFormatter = new Intl.DateTimeFormat(DEFAULT_LOCALE, {
+export const dateTimeFormatter = new Intl.DateTimeFormat(DEFAULT_LOCALE, {
   year: "numeric",
   month: "short",
   day: "numeric",


### PR DESCRIPTION
## Summary

Improve performance of formatting utilities by reusing cached `Intl` formatters instead of creating new instances on every call.

---

## What Changed

* Updated `formatCurrency`, `formatDate`, and `formatDateTime` in `client-utils.ts` to use shared, cached formatters from `constants.ts`
* Replaced per-call instantiation of:

  * `Intl.NumberFormat`
  * `Intl.DateTimeFormat`
* Preserved all existing function signatures and return formats
* Kept existing parsing and guard logic unchanged

---

## Why

Previously, each call to the formatting helpers created a new `Intl` formatter instance. Since these functions are used across 20+ files and often run during render cycles, this resulted in unnecessary object allocation.

By reusing module-level cached formatters, this change:

* reduces repeated allocations
* improves runtime efficiency
* aligns with the existing pattern already defined in `constants.ts`

---

## Risk

Low — no changes to output format or function signatures. All existing consumers continue to work without modification.

---

## Verification

* Verified that currency and date outputs remain unchanged
* Ran existing tests (e.g., `vitest run`) to confirm no regressions

---

Closes #311 