### PR TITLE
chore(api): remove no-op requireAdvisor false from D2C routes

### DIFF
--- a/src/app/api/d2c/applications/[clientId]/status/route.ts
+++ b/src/app/api/d2c/applications/[clientId]/status/route.ts
@@ -42,7 +42,6 @@ export const GET = withApiHandler(
   {
     endpoint: "/api/d2c/applications/[clientId]/status",
     method: "GET",
-    requireAdvisor: false,
   },
   async (_request, { logger, session, params }) => {
     const clientGuard = await requireClientAccount(logger, session);

--- a/src/app/api/d2c/draft/[clientId]/route.ts
+++ b/src/app/api/d2c/draft/[clientId]/route.ts
@@ -84,7 +84,6 @@ export const GET = withApiHandler(
   {
     endpoint: "/api/d2c/draft/[clientId]",
     method: "GET",
-    requireAdvisor: false,
   },
   async (_request, { logger, session, params }) => {
     const clientGuard = await requireClientAccount(logger, session);
@@ -137,7 +136,6 @@ export const PATCH = withApiHandler(
   {
     endpoint: "/api/d2c/draft/[clientId]",
     method: "PATCH",
-    requireAdvisor: false,
   },
   async (request, { logger, session, params }) => {
     const clientGuard = await requireClientAccount(logger, session);

--- a/src/app/api/d2c/draft/route.ts
+++ b/src/app/api/d2c/draft/route.ts
@@ -73,7 +73,6 @@ export const POST = withApiHandler(
   {
     endpoint: "/api/d2c/draft",
     method: "POST",
-    requireAdvisor: false,
   },
   async (request, { logger, session }) => {
     const clientGuard = await requireClientAccount(logger, session);
@@ -155,7 +154,6 @@ export const GET = withApiHandler(
   {
     endpoint: "/api/d2c/draft",
     method: "GET",
-    requireAdvisor: false,
   },
   async (_request, { logger, session }) => {
     const clientGuard = await requireClientAccount(logger, session);

--- a/src/app/api/d2c/resume-links/[token]/route.ts
+++ b/src/app/api/d2c/resume-links/[token]/route.ts
@@ -39,7 +39,6 @@ export const GET = withApiHandler(
     endpoint: "/api/d2c/resume-links/[token]",
     method: "GET",
     // Not requiring advisor - this is for D2C consumers
-    requireAdvisor: false,
   },
   async (_request, { logger, session, params }) => {
     const token = params.token;

--- a/src/app/api/d2c/resume-links/route.ts
+++ b/src/app/api/d2c/resume-links/route.ts
@@ -34,7 +34,6 @@ export const POST = withApiHandler(
     endpoint: "/api/d2c/resume-links",
     method: "POST",
     // Note: Not requiring advisor - this is for D2C consumers
-    requireAdvisor: false,
   },
   async (request, { logger, session }) => {
     // Parse and validate request body


### PR DESCRIPTION
## Summary

Remove redundant `requireAdvisor: false` from D2C API route handler configs.

---

## What Changed

* Removed explicit `requireAdvisor: false` from 7 route handlers in `src/app/api/`
* No other configuration changes were made

---

## Why

`requireAdvisor` is already falsy by default in `withApiHandler`, so explicitly setting it to `false` is a no-op. Removing it reduces noise and keeps the route configs cleaner.

---

## Risk

Low — behavior is unchanged since `requireAdvisor` is only enforced when truthy.

---

## Verification

* Confirmed default behavior in `withApiHandler`
* Verified all occurrences were removed
* Ran lint/typecheck for touched files
---
Closes #315 