### PR TITLE
refactor: split client report view into focused sections

### DIFF
--- a/docs/plans/2026-04-02-client-report-view-refactor.md
+++ b/docs/plans/2026-04-02-client-report-view-refactor.md
@@ -1,0 +1,81 @@
+# Client Report View Refactor Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Split `ClientReportView` into focused sub-components without changing report behavior.
+
+**Architecture:** Keep `ClientReportView` as the composition root for data loading, insurance hook usage, and download handlers. Move header and report sections into presentational components inside `src/components/clients/report/`, and share a small section wrapper so repeated card markup stays consistent.
+
+**Tech Stack:** Next.js, React 19, TypeScript, Tailwind CSS, shadcn/ui, Vitest, Testing Library
+
+---
+
+### Task 1: Lock the intended component API with tests
+
+**Files:**
+
+- Create: `src/components/clients/report/client-report-components.test.tsx`
+- Reference: `src/components/clients/client-report-view.tsx`
+
+**Step 1: Write the failing tests**
+
+- Assert `ClientReportHeader` renders the client name, demo badge, and both action buttons when enabled.
+- Assert `ClientReportPdfTrigger` renders loading text and disabled state.
+- Assert `ClientReportSection` renders title, description, and children.
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun vitest run src/components/clients/report/client-report-components.test.tsx`
+Expected: FAIL because the new report components do not exist yet.
+
+### Task 2: Extract focused report components
+
+**Files:**
+
+- Create: `src/components/clients/report/client-report-header.tsx`
+- Create: `src/components/clients/report/client-report-pdf-trigger.tsx`
+- Create: `src/components/clients/report/client-report-section.tsx`
+- Create: `src/components/clients/report/client-report-profile-section.tsx`
+- Create: `src/components/clients/report/client-report-financial-inputs-section.tsx`
+- Create: `src/components/clients/report/client-report-net-worth-section.tsx`
+- Create: `src/components/clients/report/client-report-insurance-section.tsx`
+- Create: `src/components/clients/report/index.ts`
+
+**Step 3: Write minimal implementation**
+
+- Build pure presentational components that accept already-computed props.
+- Preserve existing markup, copy, and classes.
+- Keep download button state text and demo/compliance button rules unchanged.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `bun vitest run src/components/clients/report/client-report-components.test.tsx`
+Expected: PASS.
+
+### Task 3: Recompose `ClientReportView`
+
+**Files:**
+
+- Modify: `src/components/clients/client-report-view.tsx`
+
+**Step 5: Replace inline sections with extracted components**
+
+- Keep hook usage, state, totals, and handler logic in the root.
+- Import the new report components from `src/components/clients/report/`.
+- Reduce the root component to orchestration and prop wiring.
+
+**Step 6: Run focused verification**
+
+Run: `bun vitest run src/components/clients/report/client-report-components.test.tsx src/components/clients/client-report-view-footer.test.tsx`
+Expected: PASS.
+
+### Task 4: Run task-scoped quality checks
+
+**Files:**
+
+- Verify only
+
+**Step 7: Run lint + typecheck for touched files**
+
+Run: `bun run check`
+Expected: PASS.

--- a/src/components/clients/client-report-view-footer.test.tsx
+++ b/src/components/clients/client-report-view-footer.test.tsx
@@ -1,19 +1,15 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-
-function ReportFooterCopy() {
-  return (
-    <p>
-      This report is generated for informational purposes only and should not be
-      considered financial advice. Please consult with a licensed insurance
-      professional for personalized recommendations.
-    </p>
-  );
-}
+import { ClientReportFooter } from "@/components/clients/report";
 
 describe("Client report footer copy", () => {
   it("avoids advisor-specific recommendation language", () => {
-    render(<ReportFooterCopy />);
+    render(
+      <ClientReportFooter
+        clientId="client-1"
+        updatedAt="2026-04-04T12:00:00.000Z"
+      />,
+    );
 
     expect(screen.queryByText(/financial advisor/i)).toBeNull();
     expect(screen.getByText(/licensed insurance professional/i)).toBeTruthy();

--- a/src/components/clients/client-report-view.tsx
+++ b/src/components/clients/client-report-view.tsx
@@ -1,56 +1,27 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Button } from "@/components/ui/button";
-import {
-  User,
-  Calendar,
-  MapPin,
-  Heart,
-  Cigarette,
-  FileText,
-  Download,
-  DollarSign,
-  Clock,
-  Shield,
-  ClipboardCheck,
-} from "lucide-react";
+import { ClipboardCheck } from "lucide-react";
 import { toast } from "sonner";
 import type { Client } from "@/types/client";
 import type { Asset } from "@/types/asset";
 import type { Debt } from "@/types/debt";
 import type { InsuranceNeedsResult } from "@/lib/hooks/use-insurance-needs";
-import {
-  calculateAge,
-  calculateAssetTotals,
-  formatCurrency,
-  formatDate,
-  formatDateTime,
-} from "@/lib/client-utils";
+import { calculateAssetTotals } from "@/lib/client-utils";
 import { useInsuranceNeeds } from "@/lib/hooks/use-insurance-needs";
-import {
-  InsuranceNeedsCard,
-  InsuranceNeedsChart,
-} from "@/components/clients/insurance-needs";
-import { AssetsSummary } from "@/components/clients/assets-summary";
-import { DebtsSummary } from "@/components/clients/debts-summary";
 import { AISummaryCard } from "@/components/clients/ai-summary-card";
-import { NetWorthProjectionChart } from "@/components/clients/charts/net-worth-projection-chart";
-import { TaxBurdenChart } from "@/components/clients/charts/tax-burden-chart";
-import { LiquidityAnalysisChart } from "@/components/clients/charts/liquidity-analysis-chart";
-import { BeneficiaryDistributionChart } from "@/components/clients/charts/beneficiary-distribution-chart";
-import { AssetDiversificationChart } from "@/components/clients/charts/asset-diversification-chart";
-import { DebtAmortizationChart } from "@/components/clients/charts/debt-amortization-chart";
-import { GoalsProgressChart } from "@/components/clients/charts/goals-progress-chart";
+import {
+  ClientReportAnalysisSection,
+  ClientReportFinancialInputsSection,
+  ClientReportFooter,
+  ClientReportHeader,
+  ClientReportInsuranceSection,
+  ClientReportNetWorthSection,
+  ClientReportPdfTrigger,
+  ClientReportProfileSection,
+} from "@/components/clients/report";
 
 /** Default settling costs fallback when no insurance result is available */
 const DEFAULT_SETTLING_COSTS = 15000;
@@ -246,397 +217,77 @@ export function ClientReportView({
     }
   };
 
-  // Generate initials for avatar
-  const initials =
-    `${client.firstName.charAt(0)}${client.lastName.charAt(0)}`.toUpperCase();
-
   return (
     <div className="space-y-8 print:space-y-4">
-      {/* Report Header */}
-      <Card className="border-border/60 overflow-hidden py-0 shadow-sm print:border-gray-300 print:shadow-none">
-        {/* Use explicit deep navy color for consistent branding across themes */}
-        <div className="relative bg-[oklch(0.35_0.08_250)] px-6 py-6 print:bg-gray-100">
-          {/* Decorative elements */}
-          <div className="absolute -top-12 -right-12 h-32 w-32 rounded-full bg-white/5 blur-xl" />
-          <div className="absolute -bottom-8 -left-8 h-24 w-24 rounded-full bg-white/5 blur-xl" />
+      <ClientReportHeader
+        client={client}
+        isDemo={isDemo}
+        generatedAt={new Date().toISOString()}
+        showPdfTrigger={!!pdfDownloadUrl}
+        pdfTrigger={
+          pdfDownloadUrl ? (
+            <ClientReportPdfTrigger
+              isDownloading={isDownloadingPdf}
+              onDownload={handleDownloadPdf}
+              label="Download PDF"
+              loadingLabel="Preparing PDF..."
+            />
+          ) : undefined
+        }
+        complianceTrigger={
+          !isDemo ? (
+            <ClientReportPdfTrigger
+              isDownloading={isDownloadingPacket}
+              onDownload={handleDownloadCompliancePacket}
+              label="Compliance Packet"
+              loadingLabel="Preparing Packet..."
+              icon={<ClipboardCheck className="mr-2 h-4 w-4" />}
+            />
+          ) : undefined
+        }
+      />
 
-          <div className="relative z-10 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-            <div className="flex items-start gap-4">
-              {/* Client avatar */}
-              <div className="flex h-14 w-14 items-center justify-center rounded-xl bg-white/10 text-xl font-semibold text-white backdrop-blur-sm">
-                {initials}
-              </div>
-              <div>
-                <div className="mb-1 flex items-center gap-2">
-                  <h2 className="font-display text-2xl font-semibold tracking-tight text-white print:text-xl print:text-gray-900">
-                    {client.firstName} {client.lastName}
-                  </h2>
-                  {isDemo && (
-                    <Badge
-                      variant="secondary"
-                      className="border-white/20 bg-white/10 text-white"
-                    >
-                      Demo
-                    </Badge>
-                  )}
-                </div>
-                <div className="flex flex-wrap items-center gap-3 text-sm text-white/70 print:text-gray-600">
-                  <span className="flex items-center gap-1.5">
-                    <FileText className="h-3.5 w-3.5" />
-                    Financial Needs Analysis
-                  </span>
-                  <span className="hidden sm:inline">•</span>
-                  <span className="flex items-center gap-1.5">
-                    <Clock className="h-3.5 w-3.5" />
-                    {formatDateTime(new Date().toISOString())}
-                  </span>
-                </div>
-              </div>
-            </div>
-            <div className="flex gap-2 print:hidden">
-              {pdfDownloadUrl && (
-                <Button
-                  onClick={handleDownloadPdf}
-                  disabled={isDownloadingPdf}
-                  variant="secondary"
-                  className="border-white/20 bg-white/10 text-white backdrop-blur-sm hover:bg-white/20"
-                >
-                  <Download className="mr-2 h-4 w-4" />
-                  {isDownloadingPdf ? "Preparing PDF..." : "Download PDF"}
-                </Button>
-              )}
-              {!isDemo && (
-                <Button
-                  onClick={handleDownloadCompliancePacket}
-                  disabled={isDownloadingPacket}
-                  variant="secondary"
-                  className="border-white/20 bg-white/10 text-white backdrop-blur-sm hover:bg-white/20"
-                >
-                  <ClipboardCheck className="mr-2 h-4 w-4" />
-                  {isDownloadingPacket
-                    ? "Preparing Packet..."
-                    : "Compliance Packet"}
-                </Button>
-              )}
-            </div>
-          </div>
-        </div>
-      </Card>
+      <ClientReportProfileSection client={client} />
 
-      {/* Client Profile */}
-      <Card className="border-border/60 shadow-sm print:border-gray-300 print:shadow-none">
-        <CardHeader className="pb-4 print:pb-2">
-          <div className="flex items-center gap-3">
-            <div className="bg-primary/5 flex h-10 w-10 items-center justify-center rounded-lg">
-              <User className="text-primary h-5 w-5" />
-            </div>
-            <div>
-              <CardTitle className="text-lg">Client Profile</CardTitle>
-              <CardDescription>
-                Personal and demographic information
-              </CardDescription>
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <div className="grid gap-6 md:grid-cols-3 print:grid-cols-3">
-            <div className="flex items-start gap-3">
-              <Calendar className="text-muted-foreground mt-0.5 h-4 w-4" />
-              <div>
-                <p className="text-muted-foreground text-sm">Age</p>
-                <p className="font-medium">
-                  {calculateAge(client.dateOfBirth)} years
-                  <span className="text-muted-foreground ml-1 text-sm font-normal">
-                    (DOB: {formatDate(client.dateOfBirth)})
-                  </span>
-                </p>
-              </div>
-            </div>
+      <ClientReportFinancialInputsSection client={client} />
 
-            <div className="flex items-start gap-3">
-              <MapPin className="text-muted-foreground mt-0.5 h-4 w-4" />
-              <div>
-                <p className="text-muted-foreground text-sm">State</p>
-                <p className="font-medium tracking-wide uppercase">
-                  {client.state}
-                </p>
-              </div>
-            </div>
+      <ClientReportNetWorthSection
+        assets={assets}
+        debts={debts}
+        totalAssets={totalAssets}
+        isLoadingData={isLoadingData}
+      />
 
-            <div className="flex items-start gap-3">
-              <User className="text-muted-foreground mt-0.5 h-4 w-4" />
-              <div>
-                <p className="text-muted-foreground text-sm">Sex</p>
-                <p className="font-medium">
-                  {client.sex === "M"
-                    ? "Male"
-                    : client.sex === "F"
-                      ? "Female"
-                      : "Not specified"}
-                </p>
-              </div>
-            </div>
-
-            <div className="flex items-start gap-3">
-              <Cigarette className="text-muted-foreground mt-0.5 h-4 w-4" />
-              <div>
-                <p className="text-muted-foreground text-sm">Smoker Status</p>
-                <Badge
-                  variant={client.smoker ? "destructive" : "outline"}
-                  className={
-                    client.smoker
-                      ? ""
-                      : "border-emerald/30 bg-emerald/5 text-emerald"
-                  }
-                >
-                  {client.smoker ? "Smoker" : "Non-Smoker"}
-                </Badge>
-              </div>
-            </div>
-
-            <div className="flex items-start gap-3">
-              <Heart className="text-muted-foreground mt-0.5 h-4 w-4" />
-              <div>
-                <p className="text-muted-foreground text-sm">Health Rating</p>
-                <Badge variant="outline" className="capitalize">
-                  {client.healthRating || "Standard"}
-                </Badge>
-              </div>
-            </div>
-
-            {client.hasSpouse && (
-              <div className="flex items-start gap-3">
-                <User className="text-muted-foreground mt-0.5 h-4 w-4" />
-                <div>
-                  <p className="text-muted-foreground text-sm">Spouse Age</p>
-                  <p className="font-medium">
-                    {client.spouseAge
-                      ? `${client.spouseAge} years`
-                      : "Not specified"}
-                  </p>
-                </div>
-              </div>
-            )}
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Financial Inputs Summary */}
-      <Card className="border-border/60 shadow-sm print:border-gray-300 print:shadow-none">
-        <CardHeader className="pb-4 print:pb-2">
-          <div className="flex items-center gap-3">
-            <div className="bg-primary/5 flex h-10 w-10 items-center justify-center rounded-lg">
-              <DollarSign className="text-primary h-5 w-5" />
-            </div>
-            <div>
-              <CardTitle className="text-lg">Financial Inputs</CardTitle>
-              <CardDescription>
-                Income and insurance planning parameters
-              </CardDescription>
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 print:grid-cols-4">
-            <div className="bg-muted/30 rounded-xl border p-4 print:p-2">
-              <p className="text-muted-foreground text-sm">
-                Client Annual Income
-              </p>
-              <p className="font-currency mt-1 text-xl font-semibold">
-                {formatCurrency(parseFloat(client.clientIncome || "0") || 0)}
-              </p>
-            </div>
-
-            {client.spouseIncome && parseFloat(client.spouseIncome) > 0 && (
-              <div className="bg-muted/30 rounded-xl border p-4 print:p-2">
-                <p className="text-muted-foreground text-sm">
-                  Spouse Annual Income
-                </p>
-                <p className="font-currency mt-1 text-xl font-semibold">
-                  {formatCurrency(parseFloat(client.spouseIncome) || 0)}
-                </p>
-              </div>
-            )}
-
-            <div className="bg-muted/30 rounded-xl border p-4 print:p-2">
-              <p className="text-muted-foreground text-sm">
-                Income Replacement
-              </p>
-              <p className="font-currency mt-1 text-xl font-semibold">
-                {client.incomeReplacementPercent || "70"}%
-              </p>
-              <p className="text-muted-foreground mt-0.5 text-xs">
-                for {client.replacementDurationYears || 10} years
-              </p>
-            </div>
-
-            <div className="bg-muted/30 rounded-xl border p-4 print:p-2">
-              <p className="text-muted-foreground text-sm">
-                Existing Life Insurance
-              </p>
-              <p className="font-currency mt-1 text-xl font-semibold">
-                {formatCurrency(
-                  parseFloat(client.existingLifeInsuranceCoverage || "0") || 0,
-                )}
-              </p>
-            </div>
-          </div>
-
-          {client.additionalGoals && (
-            <div className="border-border/60 mt-6 border-t pt-4">
-              <p className="text-muted-foreground mb-2 text-sm font-medium">
-                Additional Goals & Notes
-              </p>
-              <p className="text-foreground text-sm leading-relaxed whitespace-pre-wrap">
-                {client.additionalGoals}
-              </p>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* Assets & Debts Summary */}
-      <Card className="border-border/60 shadow-sm print:border-gray-300 print:shadow-none">
-        <CardHeader className="pb-4 print:pb-2">
-          <div className="flex items-center gap-3">
-            <div className="bg-primary/5 flex h-10 w-10 items-center justify-center rounded-lg">
-              <Shield className="text-primary h-5 w-5" />
-            </div>
-            <div>
-              <CardTitle className="text-lg">Net Worth Summary</CardTitle>
-              <CardDescription>
-                Assets, liabilities, and net position
-              </CardDescription>
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {isLoadingData ? (
-            <div className="grid gap-4 md:grid-cols-2">
-              <Skeleton className="h-24" />
-              <Skeleton className="h-24" />
-            </div>
-          ) : (
-            <>
-              <AssetsSummary items={assets} />
-              <DebtsSummary items={debts} totalAssets={totalAssets} />
-            </>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* Insurance Needs Analysis */}
-      <div className="print:break-before-page">
-        <div className="mb-6 flex items-center gap-3">
-          <div className="bg-emerald h-1 w-1 rounded-full" />
-          <h3 className="font-display text-foreground text-xl font-semibold tracking-tight print:text-base">
-            Insurance Needs Analysis
-          </h3>
-        </div>
-        <div className="grid gap-6 lg:grid-cols-2 print:block print:space-y-4">
-          <InsuranceNeedsCard
-            result={insuranceResult}
-            confidence={isDemo ? null : insuranceConfidence}
-            isLoading={!isDemo && isInsuranceLoading}
-            error={isDemo ? null : insuranceError}
-            onRecalculate={isDemo ? undefined : recalculateInsurance}
-            calculatedAt={
-              isDemo ? new Date().toISOString() : insuranceCalculatedAt
-            }
-            isReadOnly={isDemo}
-            clientStateCode={client.state}
-          />
-          <InsuranceNeedsChart
-            result={insuranceResult}
-            isLoading={!isDemo && isInsuranceLoading}
-          />
-        </div>
-      </div>
+      <ClientReportInsuranceSection
+        insuranceResult={insuranceResult ?? null}
+        insuranceConfidence={isDemo ? null : insuranceConfidence}
+        isDemo={isDemo}
+        isInsuranceLoading={isInsuranceLoading}
+        insuranceError={isDemo ? null : insuranceError}
+        recalculateInsurance={isDemo ? undefined : recalculateInsurance}
+        insuranceCalculatedAt={
+          isDemo ? new Date().toISOString() : insuranceCalculatedAt
+        }
+        clientStateCode={client.state}
+      />
 
       {/* AI Recommendation Letter */}
       <div className="print:break-before-page">
         <AISummaryCard clientId={clientId} demoLetter={demoLetter} />
       </div>
 
-      {/* Interactive Charts Section */}
-      <div className="space-y-6 print:hidden">
-        <h3 className="font-display text-foreground text-xl font-semibold tracking-tight">
-          Financial Analysis & Projections
-        </h3>
+      <ClientReportAnalysisSection
+        assets={assets}
+        debts={debts}
+        client={client}
+        totalAssets={totalAssets}
+        totalDebts={totalDebts}
+        settlingCosts={
+          insuranceResult?.estateBufferNeeds || DEFAULT_SETTLING_COSTS
+        }
+      />
 
-        <div className="grid gap-6 lg:grid-cols-2">
-          <NetWorthProjectionChart
-            assets={assets}
-            debts={debts}
-            clientIncome={Number(client.clientIncome || 0)}
-          />
-
-          <TaxBurdenChart assets={assets} state={client.state} />
-        </div>
-
-        <LiquidityAnalysisChart
-          assets={assets}
-          debts={debts}
-          settlingCosts={
-            insuranceResult?.estateBufferNeeds || DEFAULT_SETTLING_COSTS
-          }
-        />
-
-        <div className="grid gap-6 lg:grid-cols-2">
-          <AssetDiversificationChart assets={assets} />
-
-          <BeneficiaryDistributionChart
-            assets={assets}
-            debts={totalDebts}
-            settlingCosts={
-              insuranceResult?.estateBufferNeeds || DEFAULT_SETTLING_COSTS
-            }
-          />
-        </div>
-
-        <div className="grid gap-6 lg:grid-cols-2">
-          <DebtAmortizationChart debts={debts} />
-
-          <GoalsProgressChart
-            goals={[
-              {
-                name: "Children's Education",
-                targetAmount: 100000,
-                currentFunding: client.clientIncome
-                  ? Number(client.clientIncome) * 0.1
-                  : 0,
-              },
-              {
-                name: "Retirement Savings",
-                targetAmount: 2000000,
-                currentFunding: totalAssets * 0.6,
-              },
-              {
-                name: "Emergency Fund",
-                targetAmount: 50000,
-                currentFunding: assets
-                  .filter((a) =>
-                    ["checking", "savings", "emergency_fund"].includes(a.type),
-                  )
-                  .reduce((sum, a) => sum + (Number(a.currentValue) || 0), 0),
-              },
-            ]}
-          />
-        </div>
-      </div>
-
-      {/* Report Footer */}
-      <div className="border-border/60 text-muted-foreground border-t pt-6 text-sm print:pt-2">
-        <p className="leading-relaxed">
-          This report is generated for informational purposes only and should
-          not be considered financial advice. Please consult with a licensed
-          insurance professional for personalized recommendations.
-        </p>
-        <p className="mt-3 font-mono text-xs">
-          Report ID: {clientId} | Last Updated:{" "}
-          {formatDateTime(client.updatedAt)}
-        </p>
-      </div>
+      <ClientReportFooter clientId={clientId} updatedAt={client.updatedAt} />
     </div>
   );
 }

--- a/src/components/clients/report/client-report-analysis-section.tsx
+++ b/src/components/clients/report/client-report-analysis-section.tsx
@@ -1,0 +1,97 @@
+import { AssetDiversificationChart } from "@/components/clients/charts/asset-diversification-chart";
+import { BeneficiaryDistributionChart } from "@/components/clients/charts/beneficiary-distribution-chart";
+import { DebtAmortizationChart } from "@/components/clients/charts/debt-amortization-chart";
+import { GoalsProgressChart } from "@/components/clients/charts/goals-progress-chart";
+import { LiquidityAnalysisChart } from "@/components/clients/charts/liquidity-analysis-chart";
+import { NetWorthProjectionChart } from "@/components/clients/charts/net-worth-projection-chart";
+import { TaxBurdenChart } from "@/components/clients/charts/tax-burden-chart";
+import type { Asset } from "@/types/asset";
+import type { Client } from "@/types/client";
+import type { Debt } from "@/types/debt";
+
+interface ClientReportAnalysisSectionProps {
+  assets: Asset[];
+  debts: Debt[];
+  client: Client;
+  totalAssets: number;
+  totalDebts: number;
+  settlingCosts: number;
+}
+
+export function ClientReportAnalysisSection({
+  assets,
+  debts,
+  client,
+  totalAssets,
+  totalDebts,
+  settlingCosts,
+}: ClientReportAnalysisSectionProps) {
+  return (
+    <div className="space-y-6 print:hidden">
+      <h3 className="font-display text-foreground text-xl font-semibold tracking-tight">
+        Financial Analysis & Projections
+      </h3>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <NetWorthProjectionChart
+          assets={assets}
+          debts={debts}
+          clientIncome={Number(client.clientIncome || 0)}
+        />
+
+        <TaxBurdenChart assets={assets} state={client.state} />
+      </div>
+
+      <LiquidityAnalysisChart
+        assets={assets}
+        debts={debts}
+        settlingCosts={settlingCosts}
+      />
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <AssetDiversificationChart assets={assets} />
+
+        <BeneficiaryDistributionChart
+          assets={assets}
+          debts={totalDebts}
+          settlingCosts={settlingCosts}
+        />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <DebtAmortizationChart debts={debts} />
+
+        <GoalsProgressChart
+          goals={[
+            {
+              name: "Children's Education",
+              targetAmount: 100000,
+              currentFunding: client.clientIncome
+                ? Number(client.clientIncome) * 0.1
+                : 0,
+            },
+            {
+              name: "Retirement Savings",
+              targetAmount: 2000000,
+              currentFunding: totalAssets * 0.6,
+            },
+            {
+              name: "Emergency Fund",
+              targetAmount: 50000,
+              currentFunding: assets
+                .filter((asset) =>
+                  ["checking", "savings", "emergency_fund"].includes(
+                    asset.type,
+                  ),
+                )
+                .reduce(
+                  (sum, asset) => sum + (Number(asset.currentValue) || 0),
+                  0,
+                ),
+            },
+          ]}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/clients/report/client-report-components.test.tsx
+++ b/src/components/clients/report/client-report-components.test.tsx
@@ -1,0 +1,218 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { Client } from "@/types/client";
+import type { Asset } from "@/types/asset";
+import type { Debt } from "@/types/debt";
+import {
+  ClientReportAnalysisSection,
+  ClientReportFooter,
+  ClientReportInsuranceSection,
+  ClientReportNetWorthSection,
+  ClientReportHeader,
+  ClientReportFinancialInputsSection,
+  ClientReportPdfTrigger,
+  ClientReportProfileSection,
+  ClientReportSection,
+} from "./index";
+import type { InsuranceNeedsResult } from "@/lib/hooks/use-insurance-needs";
+
+vi.mock("@/components/clients/assets-summary", () => ({
+  AssetsSummary: () => <div>Assets summary</div>,
+}));
+
+vi.mock("@/components/clients/debts-summary", () => ({
+  DebtsSummary: () => <div>Debts summary</div>,
+}));
+
+vi.mock("@/components/clients/insurance-needs", () => ({
+  InsuranceNeedsCard: () => <div>Insurance needs card</div>,
+  InsuranceNeedsChart: () => <div>Insurance needs chart</div>,
+}));
+
+vi.mock("@/components/clients/charts/net-worth-projection-chart", () => ({
+  NetWorthProjectionChart: () => <div>Net worth projection</div>,
+}));
+
+vi.mock("@/components/clients/charts/tax-burden-chart", () => ({
+  TaxBurdenChart: () => <div>Tax burden chart</div>,
+}));
+
+vi.mock("@/components/clients/charts/liquidity-analysis-chart", () => ({
+  LiquidityAnalysisChart: () => <div>Liquidity analysis</div>,
+}));
+
+vi.mock("@/components/clients/charts/asset-diversification-chart", () => ({
+  AssetDiversificationChart: () => <div>Asset diversification</div>,
+}));
+
+vi.mock("@/components/clients/charts/beneficiary-distribution-chart", () => ({
+  BeneficiaryDistributionChart: () => <div>Beneficiary distribution</div>,
+}));
+
+vi.mock("@/components/clients/charts/debt-amortization-chart", () => ({
+  DebtAmortizationChart: () => <div>Debt amortization</div>,
+}));
+
+vi.mock("@/components/clients/charts/goals-progress-chart", () => ({
+  GoalsProgressChart: () => <div>Goals progress</div>,
+}));
+
+const baseClient: Client = {
+  id: "client-1",
+  firstName: "Ada",
+  lastName: "Lovelace",
+  dateOfBirth: "1985-12-10",
+  state: "ON",
+  status: "active",
+  sex: "F",
+  smoker: false,
+  healthRating: "preferred",
+  hasSpouse: false,
+  updatedAt: "2026-01-02T00:00:00.000Z",
+};
+
+const baseAssets: Asset[] = [
+  {
+    id: "asset-1",
+    clientId: "client-1",
+    name: "Cash",
+    type: "savings",
+    currentValue: "25000",
+    isLiquid: true,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-02T00:00:00.000Z",
+    deletedAt: null,
+  },
+];
+
+const baseDebts: Debt[] = [
+  {
+    id: "debt-1",
+    clientId: "client-1",
+    name: "Home loan",
+    type: "mortgage",
+    currentBalance: "100000",
+    deletedAt: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-02T00:00:00.000Z",
+  },
+];
+
+const insuranceResult: InsuranceNeedsResult = {
+  incomeReplacementNeeds: 100000,
+  debtPayoffNeeds: 100000,
+  estateBufferNeeds: 15000,
+  grossNeeds: 215000,
+  existingCoverage: 25000,
+  liquidAssets: 25000,
+  totalInsuranceNeeds: 165000,
+  inputsUsed: {
+    clientIncome: 90000,
+    spouseIncome: 0,
+    includeSpouseIncome: false,
+    incomeReplacementPercent: 70,
+    replacementDurationYears: 10,
+    estateBufferType: "fixed",
+    estateBufferValue: 15000,
+  },
+};
+
+describe("client report extracted components", () => {
+  it("renders the report header with demo badge and actions", () => {
+    render(
+      <ClientReportHeader
+        client={baseClient}
+        isDemo
+        generatedAt="2026-04-02T12:00:00.000Z"
+        showPdfTrigger
+        pdfTrigger={
+          <ClientReportPdfTrigger
+            isDownloading={false}
+            onDownload={vi.fn()}
+            label="Download PDF"
+            loadingLabel="Preparing PDF..."
+          />
+        }
+        complianceTrigger={<button type="button">Compliance Packet</button>}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: /ada lovelace/i })).toBeTruthy();
+    expect(screen.getByText("Demo")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Download PDF" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Compliance Packet" }),
+    ).toBeTruthy();
+  });
+
+  it("renders a pdf trigger loading state", () => {
+    render(
+      <ClientReportPdfTrigger
+        isDownloading
+        onDownload={vi.fn()}
+        label="Download PDF"
+        loadingLabel="Preparing PDF..."
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Preparing PDF..." }),
+    ).toHaveProperty("disabled", true);
+  });
+
+  it("renders a reusable report section shell", () => {
+    render(
+      <ClientReportSection title="Client Profile" description="Snapshot info">
+        <div>Section body</div>
+      </ClientReportSection>,
+    );
+
+    expect(screen.getByText("Client Profile")).toBeTruthy();
+    expect(screen.getByText("Snapshot info")).toBeTruthy();
+    expect(screen.getByText("Section body")).toBeTruthy();
+  });
+
+  it("renders the extracted report sections together", () => {
+    render(
+      <>
+        <ClientReportProfileSection client={baseClient} />
+        <ClientReportFinancialInputsSection client={baseClient} />
+        <ClientReportNetWorthSection
+          assets={baseAssets}
+          debts={baseDebts}
+          totalAssets={25000}
+          isLoadingData={false}
+        />
+        <ClientReportInsuranceSection
+          insuranceResult={insuranceResult}
+          insuranceConfidence={null}
+          isDemo={false}
+          isInsuranceLoading={false}
+          insuranceError={null}
+          recalculateInsurance={vi.fn(async () => {})}
+          insuranceCalculatedAt="2026-04-02T12:00:00.000Z"
+          clientStateCode="ON"
+        />
+        <ClientReportAnalysisSection
+          assets={baseAssets}
+          debts={baseDebts}
+          client={baseClient}
+          totalAssets={25000}
+          totalDebts={100000}
+          settlingCosts={15000}
+        />
+        <ClientReportFooter
+          clientId="client-1"
+          updatedAt="2026-04-04T12:00:00.000Z"
+        />
+      </>,
+    );
+
+    expect(screen.getByText("Client Profile")).toBeTruthy();
+    expect(screen.getByText("Financial Inputs")).toBeTruthy();
+    expect(screen.getByText("Assets summary")).toBeTruthy();
+    expect(screen.getByText("Insurance needs card")).toBeTruthy();
+    expect(screen.getByText("Net worth projection")).toBeTruthy();
+    expect(screen.getByText(/licensed insurance professional/i)).toBeTruthy();
+  });
+});

--- a/src/components/clients/report/client-report-financial-inputs-section.tsx
+++ b/src/components/clients/report/client-report-financial-inputs-section.tsx
@@ -1,0 +1,72 @@
+import { DollarSign } from "lucide-react";
+import type { Client } from "@/types/client";
+import { formatCurrency } from "@/lib/client-utils";
+import { ClientReportSection } from "./client-report-section";
+
+interface ClientReportFinancialInputsSectionProps {
+  client: Client;
+}
+
+export function ClientReportFinancialInputsSection({
+  client,
+}: ClientReportFinancialInputsSectionProps) {
+  return (
+    <ClientReportSection
+      title="Financial Inputs"
+      description="Income and insurance planning parameters"
+      icon={<DollarSign className="text-primary h-5 w-5" />}
+    >
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 print:grid-cols-4">
+        <div className="bg-muted/30 rounded-xl border p-4 print:p-2">
+          <p className="text-muted-foreground text-sm">Client Annual Income</p>
+          <p className="font-currency mt-1 text-xl font-semibold">
+            {formatCurrency(parseFloat(client.clientIncome || "0") || 0)}
+          </p>
+        </div>
+
+        {client.spouseIncome && parseFloat(client.spouseIncome) > 0 ? (
+          <div className="bg-muted/30 rounded-xl border p-4 print:p-2">
+            <p className="text-muted-foreground text-sm">
+              Spouse Annual Income
+            </p>
+            <p className="font-currency mt-1 text-xl font-semibold">
+              {formatCurrency(parseFloat(client.spouseIncome) || 0)}
+            </p>
+          </div>
+        ) : null}
+
+        <div className="bg-muted/30 rounded-xl border p-4 print:p-2">
+          <p className="text-muted-foreground text-sm">Income Replacement</p>
+          <p className="font-currency mt-1 text-xl font-semibold">
+            {client.incomeReplacementPercent || "70"}%
+          </p>
+          <p className="text-muted-foreground mt-0.5 text-xs">
+            for {client.replacementDurationYears || 10} years
+          </p>
+        </div>
+
+        <div className="bg-muted/30 rounded-xl border p-4 print:p-2">
+          <p className="text-muted-foreground text-sm">
+            Existing Life Insurance
+          </p>
+          <p className="font-currency mt-1 text-xl font-semibold">
+            {formatCurrency(
+              parseFloat(client.existingLifeInsuranceCoverage || "0") || 0,
+            )}
+          </p>
+        </div>
+      </div>
+
+      {client.additionalGoals ? (
+        <div className="border-border/60 mt-6 border-t pt-4">
+          <p className="text-muted-foreground mb-2 text-sm font-medium">
+            Additional Goals & Notes
+          </p>
+          <p className="text-foreground text-sm leading-relaxed whitespace-pre-wrap">
+            {client.additionalGoals}
+          </p>
+        </div>
+      ) : null}
+    </ClientReportSection>
+  );
+}

--- a/src/components/clients/report/client-report-footer.tsx
+++ b/src/components/clients/report/client-report-footer.tsx
@@ -1,0 +1,24 @@
+import { formatDateTime } from "@/lib/client-utils";
+
+interface ClientReportFooterProps {
+  clientId: string;
+  updatedAt: string;
+}
+
+export function ClientReportFooter({
+  clientId,
+  updatedAt,
+}: ClientReportFooterProps) {
+  return (
+    <div className="border-border/60 text-muted-foreground border-t pt-6 text-sm print:pt-2">
+      <p className="leading-relaxed">
+        This report is generated for informational purposes only and should not
+        be considered financial advice. Please consult with a licensed insurance
+        professional for personalized recommendations.
+      </p>
+      <p className="mt-3 font-mono text-xs">
+        Report ID: {clientId} | Last Updated: {formatDateTime(updatedAt)}
+      </p>
+    </div>
+  );
+}

--- a/src/components/clients/report/client-report-header.tsx
+++ b/src/components/clients/report/client-report-header.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from "react";
+import { Clock, FileText } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { Client } from "@/types/client";
+import { formatDateTime } from "@/lib/client-utils";
+import { Card } from "@/components/ui/card";
+
+interface ClientReportHeaderProps {
+  client: Client;
+  isDemo: boolean;
+  generatedAt: string;
+  showPdfTrigger?: boolean;
+  pdfTrigger?: ReactNode;
+  complianceTrigger?: ReactNode;
+}
+
+export function ClientReportHeader({
+  client,
+  isDemo,
+  generatedAt,
+  showPdfTrigger,
+  pdfTrigger,
+  complianceTrigger,
+}: ClientReportHeaderProps) {
+  const initials =
+    `${client.firstName.charAt(0)}${client.lastName.charAt(0)}`.toUpperCase();
+
+  return (
+    <Card className="border-border/60 overflow-hidden py-0 shadow-sm print:border-gray-300 print:shadow-none">
+      <div className="relative bg-[oklch(0.35_0.08_250)] px-6 py-6 print:bg-gray-100">
+        <div className="absolute -top-12 -right-12 h-32 w-32 rounded-full bg-white/5 blur-xl" />
+        <div className="absolute -bottom-8 -left-8 h-24 w-24 rounded-full bg-white/5 blur-xl" />
+
+        <div className="relative z-10 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex items-start gap-4">
+            <div className="flex h-14 w-14 items-center justify-center rounded-xl bg-white/10 text-xl font-semibold text-white backdrop-blur-sm">
+              {initials}
+            </div>
+            <div>
+              <div className="mb-1 flex items-center gap-2">
+                <h2 className="font-display text-2xl font-semibold tracking-tight text-white print:text-xl print:text-gray-900">
+                  {client.firstName} {client.lastName}
+                </h2>
+                {isDemo ? (
+                  <Badge
+                    variant="secondary"
+                    className="border-white/20 bg-white/10 text-white"
+                  >
+                    Demo
+                  </Badge>
+                ) : null}
+              </div>
+              <div className="flex flex-wrap items-center gap-3 text-sm text-white/70 print:text-gray-600">
+                <span className="flex items-center gap-1.5">
+                  <FileText className="h-3.5 w-3.5" />
+                  Financial Needs Analysis
+                </span>
+                <span className="hidden sm:inline">•</span>
+                <span className="flex items-center gap-1.5">
+                  <Clock className="h-3.5 w-3.5" />
+                  {formatDateTime(generatedAt)}
+                </span>
+              </div>
+            </div>
+          </div>
+          <div className="flex gap-2 print:hidden">
+            {showPdfTrigger ? pdfTrigger : null}
+            {complianceTrigger}
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/clients/report/client-report-insurance-section.tsx
+++ b/src/components/clients/report/client-report-insurance-section.tsx
@@ -1,0 +1,57 @@
+import type { InsuranceNeedsResult } from "@/lib/hooks/use-insurance-needs";
+import type { ConfidenceResult } from "@/lib/financial/confidence-scoring";
+import {
+  InsuranceNeedsCard,
+  InsuranceNeedsChart,
+} from "@/components/clients/insurance-needs";
+
+interface ClientReportInsuranceSectionProps {
+  insuranceResult: InsuranceNeedsResult | null;
+  insuranceConfidence: ConfidenceResult | null;
+  isDemo: boolean;
+  isInsuranceLoading: boolean;
+  insuranceError: string | null;
+  recalculateInsurance?: () => Promise<void>;
+  insuranceCalculatedAt: string | null;
+  clientStateCode: string;
+}
+
+export function ClientReportInsuranceSection({
+  insuranceResult,
+  insuranceConfidence,
+  isDemo,
+  isInsuranceLoading,
+  insuranceError,
+  recalculateInsurance,
+  insuranceCalculatedAt,
+  clientStateCode,
+}: ClientReportInsuranceSectionProps) {
+  return (
+    <div className="print:break-before-page">
+      <div className="mb-6 flex items-center gap-3">
+        <div className="bg-emerald h-1 w-1 rounded-full" />
+        <h3 className="font-display text-foreground text-xl font-semibold tracking-tight print:text-base">
+          Insurance Needs Analysis
+        </h3>
+      </div>
+      <div className="grid gap-6 lg:grid-cols-2 print:block print:space-y-4">
+        <InsuranceNeedsCard
+          result={insuranceResult}
+          confidence={isDemo ? null : insuranceConfidence}
+          isLoading={!isDemo && isInsuranceLoading}
+          error={isDemo ? null : insuranceError}
+          onRecalculate={isDemo ? undefined : recalculateInsurance}
+          calculatedAt={
+            isDemo ? new Date().toISOString() : insuranceCalculatedAt
+          }
+          isReadOnly={isDemo}
+          clientStateCode={clientStateCode}
+        />
+        <InsuranceNeedsChart
+          result={insuranceResult}
+          isLoading={!isDemo && isInsuranceLoading}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/clients/report/client-report-net-worth-section.tsx
+++ b/src/components/clients/report/client-report-net-worth-section.tsx
@@ -1,0 +1,42 @@
+import { Shield } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { AssetsSummary } from "@/components/clients/assets-summary";
+import { DebtsSummary } from "@/components/clients/debts-summary";
+import type { Asset } from "@/types/asset";
+import type { Debt } from "@/types/debt";
+import { ClientReportSection } from "./client-report-section";
+
+interface ClientReportNetWorthSectionProps {
+  assets: Asset[];
+  debts: Debt[];
+  totalAssets: number;
+  isLoadingData: boolean;
+}
+
+export function ClientReportNetWorthSection({
+  assets,
+  debts,
+  totalAssets,
+  isLoadingData,
+}: ClientReportNetWorthSectionProps) {
+  return (
+    <ClientReportSection
+      title="Net Worth Summary"
+      description="Assets, liabilities, and net position"
+      icon={<Shield className="text-primary h-5 w-5" />}
+      contentClassName="space-y-4"
+    >
+      {isLoadingData ? (
+        <div className="grid gap-4 md:grid-cols-2">
+          <Skeleton className="h-24" />
+          <Skeleton className="h-24" />
+        </div>
+      ) : (
+        <>
+          <AssetsSummary items={assets} />
+          <DebtsSummary items={debts} totalAssets={totalAssets} />
+        </>
+      )}
+    </ClientReportSection>
+  );
+}

--- a/src/components/clients/report/client-report-pdf-trigger.tsx
+++ b/src/components/clients/report/client-report-pdf-trigger.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+import { Download } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface ClientReportPdfTriggerProps {
+  isDownloading: boolean;
+  onDownload: () => void;
+  label: string;
+  loadingLabel: string;
+  icon?: ReactNode;
+}
+
+export function ClientReportPdfTrigger({
+  isDownloading,
+  onDownload,
+  label,
+  loadingLabel,
+  icon,
+}: ClientReportPdfTriggerProps) {
+  return (
+    <Button
+      onClick={onDownload}
+      disabled={isDownloading}
+      variant="secondary"
+      className="border-white/20 bg-white/10 text-white backdrop-blur-sm hover:bg-white/20"
+    >
+      {icon ?? <Download className="mr-2 h-4 w-4" />}
+      {isDownloading ? loadingLabel : label}
+    </Button>
+  );
+}

--- a/src/components/clients/report/client-report-profile-section.tsx
+++ b/src/components/clients/report/client-report-profile-section.tsx
@@ -1,0 +1,101 @@
+import { Calendar, Cigarette, Heart, MapPin, User } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { Client } from "@/types/client";
+import { calculateAge, formatDate } from "@/lib/client-utils";
+import { ClientReportSection } from "./client-report-section";
+
+interface ClientReportProfileSectionProps {
+  client: Client;
+}
+
+export function ClientReportProfileSection({
+  client,
+}: ClientReportProfileSectionProps) {
+  return (
+    <ClientReportSection
+      title="Client Profile"
+      description="Personal and demographic information"
+      icon={<User className="text-primary h-5 w-5" />}
+    >
+      <div className="grid gap-6 md:grid-cols-3 print:grid-cols-3">
+        <div className="flex items-start gap-3">
+          <Calendar className="text-muted-foreground mt-0.5 h-4 w-4" />
+          <div>
+            <p className="text-muted-foreground text-sm">Age</p>
+            <p className="font-medium">
+              {calculateAge(client.dateOfBirth)} years
+              <span className="text-muted-foreground ml-1 text-sm font-normal">
+                (DOB: {formatDate(client.dateOfBirth)})
+              </span>
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-start gap-3">
+          <MapPin className="text-muted-foreground mt-0.5 h-4 w-4" />
+          <div>
+            <p className="text-muted-foreground text-sm">State</p>
+            <p className="font-medium tracking-wide uppercase">
+              {client.state}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-start gap-3">
+          <User className="text-muted-foreground mt-0.5 h-4 w-4" />
+          <div>
+            <p className="text-muted-foreground text-sm">Sex</p>
+            <p className="font-medium">
+              {client.sex === "M"
+                ? "Male"
+                : client.sex === "F"
+                  ? "Female"
+                  : "Not specified"}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-start gap-3">
+          <Cigarette className="text-muted-foreground mt-0.5 h-4 w-4" />
+          <div>
+            <p className="text-muted-foreground text-sm">Smoker Status</p>
+            <Badge
+              variant={client.smoker ? "destructive" : "outline"}
+              className={
+                client.smoker
+                  ? ""
+                  : "border-emerald/30 bg-emerald/5 text-emerald"
+              }
+            >
+              {client.smoker ? "Smoker" : "Non-Smoker"}
+            </Badge>
+          </div>
+        </div>
+
+        <div className="flex items-start gap-3">
+          <Heart className="text-muted-foreground mt-0.5 h-4 w-4" />
+          <div>
+            <p className="text-muted-foreground text-sm">Health Rating</p>
+            <Badge variant="outline" className="capitalize">
+              {client.healthRating || "Standard"}
+            </Badge>
+          </div>
+        </div>
+
+        {client.hasSpouse ? (
+          <div className="flex items-start gap-3">
+            <User className="text-muted-foreground mt-0.5 h-4 w-4" />
+            <div>
+              <p className="text-muted-foreground text-sm">Spouse Age</p>
+              <p className="font-medium">
+                {client.spouseAge
+                  ? `${client.spouseAge} years`
+                  : "Not specified"}
+              </p>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </ClientReportSection>
+  );
+}

--- a/src/components/clients/report/client-report-section.tsx
+++ b/src/components/clients/report/client-report-section.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface ClientReportSectionProps {
+  title: string;
+  description: string;
+  children: ReactNode;
+  icon?: ReactNode;
+  contentClassName?: string;
+}
+
+export function ClientReportSection({
+  title,
+  description,
+  children,
+  icon,
+  contentClassName,
+}: ClientReportSectionProps) {
+  return (
+    <Card className="border-border/60 shadow-sm print:border-gray-300 print:shadow-none">
+      <CardHeader className="pb-4 print:pb-2">
+        <div className="flex items-center gap-3">
+          {icon ? (
+            <div className="bg-primary/5 flex h-10 w-10 items-center justify-center rounded-lg">
+              {icon}
+            </div>
+          ) : null}
+          <div>
+            <CardTitle className="text-lg">{title}</CardTitle>
+            <CardDescription>{description}</CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className={contentClassName}>{children}</CardContent>
+    </Card>
+  );
+}

--- a/src/components/clients/report/index.ts
+++ b/src/components/clients/report/index.ts
@@ -1,0 +1,9 @@
+export { ClientReportAnalysisSection } from "./client-report-analysis-section";
+export { ClientReportFinancialInputsSection } from "./client-report-financial-inputs-section";
+export { ClientReportFooter } from "./client-report-footer";
+export { ClientReportHeader } from "./client-report-header";
+export { ClientReportInsuranceSection } from "./client-report-insurance-section";
+export { ClientReportNetWorthSection } from "./client-report-net-worth-section";
+export { ClientReportPdfTrigger } from "./client-report-pdf-trigger";
+export { ClientReportProfileSection } from "./client-report-profile-section";
+export { ClientReportSection } from "./client-report-section";


### PR DESCRIPTION
## Summary
- split `ClientReportView` into focused report sub-components under `src/components/clients/report/` while keeping data loading and download orchestration in the root component
- add regression coverage for the extracted report components and switch the footer test to exercise the real `ClientReportFooter`
- include the implementation plan for issue #320 and preserve existing report behavior, including PDF/compliance actions

## Verification
- `bun vitest run src/components/clients/report/client-report-components.test.tsx src/components/clients/client-report-view-footer.test.tsx`
- `bunx eslint src/components/clients/client-report-view.tsx src/components/clients/report/**/*.tsx src/components/clients/client-report-view-footer.test.tsx`
- `bun run build`

## Notes
- `bun run check` is still blocked by the existing repo-wide `nodemailer` type resolution issue in `src/server/better-auth/password-reset-email.ts`
- Closes #320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Decomposed the client report view into smaller, focused presentational components for improved code maintainability, testability, and long-term flexibility.

* **Tests**
  * Added comprehensive test coverage for report section components, validating rendering behavior and component integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->