### PR TITLE
Bug/vercel step3

### DIFF
--- a/src/app/apply/estimate/page.test.tsx
+++ b/src/app/apply/estimate/page.test.tsx
@@ -198,16 +198,10 @@ describe("ApplyEstimatePage", () => {
     ).toBeTruthy();
   });
 
-  it("waits for auth resolution before dropping clientId on review navigation", async () => {
+  it("blocks review navigation while auth session is pending", async () => {
     useSessionMock.mockReturnValue({ data: null, isPending: true });
 
-    vi.spyOn(globalThis, "fetch").mockResolvedValue({
-      ok: true,
-      status: 201,
-      json: async () => ({
-        draft: { id: "bbbb0000-bbbb-4bbb-8bbb-bbbbbbbbbbbb" },
-      }),
-    } as Response);
+    const fetchMock = vi.spyOn(globalThis, "fetch");
 
     render(<ApplyEstimatePage />);
 
@@ -215,13 +209,12 @@ describe("ApplyEstimatePage", () => {
       name: /continue to review/i,
     });
 
+    expect((continueButton as HTMLButtonElement).disabled).toBe(true);
+
     fireEvent.click(continueButton);
 
-    await waitFor(() => {
-      expect(pushMock).toHaveBeenCalledWith(
-        "/apply/review?clientId=bbbb0000-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
-      );
-    });
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("syncs the estimate coverage before navigating to review when a draft exists", async () => {

--- a/src/app/apply/estimate/page.test.tsx
+++ b/src/app/apply/estimate/page.test.tsx
@@ -25,7 +25,7 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => ({ get: getMock }),
 }));
 
-vi.mock("@/server/better-auth/client", () => ({
+vi.mock("@/lib/auth/auth-client", () => ({
   authClient: {
     useSession: () => useSessionMock(),
   },

--- a/src/app/apply/estimate/page.tsx
+++ b/src/app/apply/estimate/page.tsx
@@ -118,9 +118,10 @@ async function findLatestDraftId(): Promise<string | null> {
     }
 
     const payload = (await response.json()) as {
+      data?: { draft?: { id?: string } };
       draft?: { id?: string };
     };
-    const foundId = payload.draft?.id;
+    const foundId = payload.data?.draft?.id ?? payload.draft?.id ?? null;
     return typeof foundId === "string" && foundId.length > 0 ? foundId : null;
   } catch {
     return null;

--- a/src/app/apply/estimate/page.tsx
+++ b/src/app/apply/estimate/page.tsx
@@ -27,6 +27,7 @@ import {
 import { mockTermLifeProvider } from "@/lib/providers/mock-term-life-provider";
 import { ProductRecommendationsCard } from "@/components/financial/product-recommendations-card";
 import type { InsuranceGoal } from "@/lib/financial/product-recommendation";
+import { authClient } from "@/server/better-auth/client";
 
 /**
  * Loads intake data, preferring DB draft when clientId is available
@@ -107,6 +108,23 @@ interface DraftPersistenceInput {
 interface DraftPersistenceResult {
   nextClientId: string | null;
   createdDraftNow: boolean;
+}
+
+async function findLatestDraftId(): Promise<string | null> {
+  try {
+    const response = await fetch("/api/d2c/draft", { method: "GET" });
+    if (!response.ok) {
+      return null;
+    }
+
+    const payload = (await response.json()) as {
+      draft?: { id?: string };
+    };
+    const foundId = payload.draft?.id;
+    return typeof foundId === "string" && foundId.length > 0 ? foundId : null;
+  } catch {
+    return null;
+  }
 }
 
 async function createDraftForReviewIfNeeded({
@@ -197,6 +215,9 @@ export default function ApplyEstimatePage() {
   const [premiumLow, setPremiumLow] = useState<number>(0);
   const [premiumHigh, setPremiumHigh] = useState<number>(0);
   const [isContinuing, setIsContinuing] = useState(false);
+  const { data: session, isPending: isSessionPending } =
+    authClient.useSession();
+  const isAuthenticated = !!session?.user;
 
   const { intake, isReady, resolvedClientId } = useIntakeData(clientId);
   const age = getAgeFromDateOfBirth(intake.dateOfBirth);
@@ -310,14 +331,29 @@ export default function ApplyEstimatePage() {
   }
 
   const handleContinueToReview = async () => {
-    if (isContinuing) return;
+    if (isContinuing || isSessionPending) return;
     setIsContinuing(true);
     try {
-      const { nextClientId, createdDraftNow } =
+      const { nextClientId: createdOrExistingClientId, createdDraftNow } =
         await createDraftForReviewIfNeeded({
           nextClientId: resolvedClientId,
           intakeForDraft,
         });
+
+      // For authenticated users, review should always be entered with a draft ID.
+      // Production can surface transient auth/persistence timing where the POST
+      // above does not return an ID on the first attempt.
+      let nextClientId = createdOrExistingClientId;
+      if (isAuthenticated && !nextClientId) {
+        nextClientId = await findLatestDraftId();
+        if (!nextClientId) {
+          console.warn("[apply/estimate] blocked continue without draft", {
+            hadResolvedClientId: !!resolvedClientId,
+            isAuthenticated,
+          });
+          return;
+        }
+      }
 
       await syncDraftForReviewIfNeeded({
         nextClientId,
@@ -394,7 +430,7 @@ export default function ApplyEstimatePage() {
           <Button
             className="bg-emerald hover:bg-emerald/90"
             onClick={() => void handleContinueToReview()}
-            disabled={isContinuing}
+            disabled={isContinuing || isSessionPending}
           >
             Continue to review
           </Button>

--- a/src/app/apply/estimate/page.tsx
+++ b/src/app/apply/estimate/page.tsx
@@ -27,7 +27,7 @@ import {
 import { mockTermLifeProvider } from "@/lib/providers/mock-term-life-provider";
 import { ProductRecommendationsCard } from "@/components/financial/product-recommendations-card";
 import type { InsuranceGoal } from "@/lib/financial/product-recommendation";
-import { authClient } from "@/server/better-auth/client";
+import { authClient } from "@/lib/auth/auth-client";
 
 /**
  * Loads intake data, preferring DB draft when clientId is available
@@ -347,11 +347,13 @@ export default function ApplyEstimatePage() {
       if (isAuthenticated && !nextClientId) {
         nextClientId = await findLatestDraftId();
         if (!nextClientId) {
-          console.warn("[apply/estimate] blocked continue without draft", {
-            hadResolvedClientId: !!resolvedClientId,
-            isAuthenticated,
-          });
-          return;
+          console.warn(
+            "[apply/estimate] continuing to review without draft id",
+            {
+              hadResolvedClientId: !!resolvedClientId,
+              isAuthenticated,
+            },
+          );
         }
       }
 

--- a/src/app/apply/review/page.test.tsx
+++ b/src/app/apply/review/page.test.tsx
@@ -87,4 +87,25 @@ describe("ApplyReviewPage", () => {
       props: { clientId: "22222222-2222-4222-8222-222222222222" },
     });
   });
+
+  it("falls back to latest owned draft when requested clientId is not found", async () => {
+    findClientMock.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      id: "33333333-3333-4333-8333-333333333333",
+    });
+
+    const { default: ApplyReviewPage } = await import("./page");
+
+    const page = await ApplyReviewPage({
+      searchParams: Promise.resolve({
+        clientId: "aaaa0000-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      }),
+    });
+
+    expect(redirectMock).not.toHaveBeenCalled();
+    expect(findClientMock).toHaveBeenCalledTimes(2);
+    expect(createDraftMock).not.toHaveBeenCalled();
+    expect(page).toMatchObject({
+      props: { clientId: "33333333-3333-4333-8333-333333333333" },
+    });
+  });
 });

--- a/src/app/apply/review/page.tsx
+++ b/src/app/apply/review/page.tsx
@@ -53,7 +53,19 @@ export default async function ApplyReviewPage({
     }
 
     const db = getDb();
-    const row = clientId
+
+    const findLatestOwnedDraft = () =>
+      db.query.client.findFirst({
+        columns: { id: true },
+        where: and(
+          eq(client.userId, session.user.id),
+          eq(client.status, "draft"),
+          isNull(client.deletedAt),
+        ),
+        orderBy: (clientTable, { desc }) => [desc(clientTable.updatedAt)],
+      });
+
+    let row = clientId
       ? await db.query.client.findFirst({
           columns: { id: true },
           where: and(
@@ -63,24 +75,33 @@ export default async function ApplyReviewPage({
             isNull(client.deletedAt),
           ),
         })
-      : await db.query.client.findFirst({
-          columns: { id: true },
-          where: and(
-            eq(client.userId, session.user.id),
-            eq(client.status, "draft"),
-            isNull(client.deletedAt),
-          ),
-          orderBy: (clientTable, { desc }) => [desc(clientTable.updatedAt)],
-        });
+      : await findLatestOwnedDraft();
+
+    // In production, immediately navigating after draft creation/update can
+    // briefly race with fresh reads. If the requested draft cannot be loaded,
+    // retry by resolving the latest owned draft instead of hard-resetting to
+    // intake.
+    if (!row && clientId) {
+      console.warn("[apply/review] Requested draft unavailable, retrying", {
+        userId: session.user.id,
+        requestedClientId: clientId,
+      });
+      row = await findLatestOwnedDraft();
+    }
 
     if (row) {
       resolvedClientId = row.id;
-    } else if (!clientId) {
+    } else {
       // Safety net: if step-3 persistence failed transiently, provision a draft
       // here so authenticated users can still proceed to review.
       const created = await createDraft(session.user.id);
       if (created.success) {
         resolvedClientId = created.draft.id;
+      } else {
+        console.warn("[apply/review] Failed to auto-provision review draft", {
+          userId: session.user.id,
+          requestedClientId: clientId ?? null,
+        });
       }
     }
   } catch (error) {

--- a/src/lib/auth/auth-client.ts
+++ b/src/lib/auth/auth-client.ts
@@ -1,0 +1,10 @@
+import { createAuthClient } from "better-auth/react";
+
+/**
+ * Browser-safe Better Auth client.
+ *
+ * This module is safe to import from Client Components.
+ */
+export const authClient = createAuthClient();
+
+export type Session = typeof authClient.$Infer.Session;


### PR DESCRIPTION
## Summary
Fixes an issue where completing step 3 (`/apply/estimate`) would incorrectly redirect users back to step 1 (`/apply/intake`) on Vercel.

## Root Cause
The review step strictly relied on the incoming `clientId`.  
If the draft lookup failed (due to timing or stale ID), the app immediately redirected to intake, resetting the flow.

This is more likely in production due to:
- read-after-write timing delays
- serverless execution behavior
- real auth/session timing

## What Changed
- Added fallback logic in `apply/review/page.tsx`:
  - Retry with latest owned draft if `clientId` lookup fails
  - Attempt to create a new draft as a safety net
  - Only redirect to intake as a last resort
- Added `findLatestOwnedDraft()` helper
- Added targeted debug logs for production
- Added regression test for fallback behavior

## Why This Fix Works
The review step no longer assumes `clientId` is always valid.

New flow:
1. Try requested draft
2. Fallback to latest owned draft
3. Attempt draft creation
4. Redirect only if all fail

Prevents unintended resets and improves resilience.

## Testing
- `bun run vitest run src/app/apply/review/page.test.tsx` ✅
- Verified fallback behavior when `clientId` is missing/invalid

## Production Impact
- Fixes step reset issue on Vercel
- Aligns production with localhost behavior
- Improves stability of application flow

## Notes
- Temporary debug logs added for validation (can be removed later)
- No broad refactors; minimal, targeted fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * "Continue to review" is disabled while authentication is resolving to prevent premature navigation.
  * When a requested draft isn't found, the app falls back to your latest owned draft instead of failing.
  * Improved draft loading reliability with race-condition mitigation and safer fallback behavior.

* **Chores**
  * Improved client-side session handling to better detect pending auth state.

* **Tests**
  * Added/updated tests covering the pending-session and draft-fallback flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->