### PR TITLE
fix(draft): replace transaction-based draft creation with DB-enforced…

### DIFF
--- a/drizzle/0018_judicious_darkstar.sql
+++ b/drizzle/0018_judicious_darkstar.sql
@@ -1,1 +1,29 @@
-CREATE UNIQUE INDEX "client_one_active_draft_per_user_idx" ON "client" USING btree ("user_id") WHERE ("status" = 'draft' AND "deleted_at" IS NULL);
+WITH ranked_d2c_drafts AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY user_id
+      ORDER BY updated_at DESC, created_at DESC, id DESC
+    ) AS rn
+  FROM "client"
+  WHERE
+    "status" = 'draft'
+    AND "deleted_at" IS NULL
+    AND "first_name" = ''
+    AND "last_name" = ''
+)
+UPDATE "client" c
+SET
+  "deleted_at" = NOW(),
+  "updated_at" = NOW()
+FROM ranked_d2c_drafts r
+WHERE c.id = r.id AND r.rn > 1;
+
+CREATE UNIQUE INDEX "client_one_active_draft_per_user_idx"
+  ON "client" USING btree ("user_id")
+  WHERE (
+    "status" = 'draft'
+    AND "deleted_at" IS NULL
+    AND "first_name" = ''
+    AND "last_name" = ''
+  );

--- a/drizzle/0018_judicious_darkstar.sql
+++ b/drizzle/0018_judicious_darkstar.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX "client_one_active_draft_per_user_idx" ON "client" USING btree ("user_id") WHERE ("status" = 'draft' AND "deleted_at" IS NULL);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1775197504455,
       "tag": "0017_opposite_wilson_fisk",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1776509100000,
+      "tag": "0018_judicious_darkstar",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/api/__tests__/d2c-draft-helpers.test.ts
+++ b/src/lib/api/__tests__/d2c-draft-helpers.test.ts
@@ -29,12 +29,14 @@ const mockTransaction = vi.fn();
 const mockExecute = vi.fn();
 
 const mockValues = vi.fn().mockReturnThis();
+const mockOnConflictDoNothing = vi.fn().mockReturnThis();
 const mockSet = vi.fn().mockReturnThis();
 const mockWhere = vi.fn().mockReturnThis();
 const mockReturning = vi.fn().mockResolvedValue([]);
 
 mockInsert.mockReturnValue({ values: mockValues });
-mockValues.mockReturnValue({ returning: mockReturning });
+mockValues.mockReturnValue({ onConflictDoNothing: mockOnConflictDoNothing });
+mockOnConflictDoNothing.mockReturnValue({ returning: mockReturning });
 mockUpdate.mockReturnValue({ set: mockSet });
 mockSet.mockReturnValue({ where: mockWhere });
 mockWhere.mockReturnValue({ returning: mockReturning });
@@ -83,6 +85,7 @@ function createMockDraft(overrides: Record<string, unknown> = {}) {
 describe("findLatestDraft", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockClientFindFirst.mockReset();
   });
 
   it("returns found: false when no draft exists", async () => {
@@ -125,20 +128,21 @@ describe("findLatestDraft", () => {
 describe("createDraft", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockTransaction.mockImplementation(async (callback: unknown) =>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (callback as any)({
-        query: {
-          client: { findFirst: mockClientFindFirst },
-        },
-        insert: mockInsert,
-        execute: mockExecute,
-      }),
-    );
+    mockClientFindFirst.mockReset();
+    mockInsert.mockReset();
+    mockValues.mockReset();
+    mockOnConflictDoNothing.mockReset();
+    mockReturning.mockReset();
+    mockInsert.mockReturnValue({ values: mockValues });
+    mockValues.mockReturnValue({
+      onConflictDoNothing: mockOnConflictDoNothing,
+    });
+    mockOnConflictDoNothing.mockReturnValue({ returning: mockReturning });
   });
 
   it("returns existing draft if one already exists (idempotent)", async () => {
     const existingDraft = createMockDraft();
+    mockReturning.mockResolvedValueOnce([]);
     mockClientFindFirst.mockResolvedValue(existingDraft);
 
     const result = await createDraft(TEST_UUIDS.validUserId);
@@ -148,19 +152,13 @@ describe("createDraft", () => {
       expect(result.existed).toBe(true);
       expect(result.draft.id).toBe(TEST_UUIDS.validClientId);
     }
-    // Should NOT call insert
-    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockInsert).toHaveBeenCalled();
   });
 
   it("creates a new draft when none exists", async () => {
     const newDraft = createMockDraft();
-    // First findFirst call returns null (no existing draft)
-    // After insert, second findFirst returns the created draft
-    mockClientFindFirst
-      .mockResolvedValueOnce(null) // findLatestDraft check
-      .mockResolvedValueOnce(newDraft); // re-fetch after insert
-
     mockReturning.mockResolvedValueOnce([{ id: TEST_UUIDS.validClientId }]);
+    mockClientFindFirst.mockResolvedValueOnce(newDraft);
 
     const result = await createDraft(TEST_UUIDS.validUserId);
 
@@ -174,11 +172,8 @@ describe("createDraft", () => {
 
   it("applies initial fields when creating", async () => {
     const newDraft = createMockDraft({ sex: "F", smoker: true });
-    mockClientFindFirst
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(newDraft);
-
     mockReturning.mockResolvedValueOnce([{ id: TEST_UUIDS.validClientId }]);
+    mockClientFindFirst.mockResolvedValueOnce(newDraft);
 
     const result = await createDraft(TEST_UUIDS.validUserId, {
       sex: "F",
@@ -190,8 +185,8 @@ describe("createDraft", () => {
   });
 
   it("returns INSERT_FAILED when insert returns no rows", async () => {
+    mockReturning.mockResolvedValueOnce([]);
     mockClientFindFirst.mockResolvedValueOnce(null);
-    mockReturning.mockResolvedValueOnce([]); // empty result from insert
 
     const result = await createDraft(TEST_UUIDS.validUserId);
 
@@ -202,11 +197,8 @@ describe("createDraft", () => {
   });
 
   it("returns INSERT_FAILED when re-fetch fails after insert", async () => {
-    mockClientFindFirst
-      .mockResolvedValueOnce(null) // findLatestDraft
-      .mockResolvedValueOnce(null); // re-fetch returns null (shouldn't happen)
-
     mockReturning.mockResolvedValueOnce([{ id: TEST_UUIDS.validClientId }]);
+    mockClientFindFirst.mockResolvedValueOnce(null); // re-fetch returns null
 
     const result = await createDraft(TEST_UUIDS.validUserId);
 
@@ -225,6 +217,11 @@ describe("createDraft", () => {
 describe("updateDraft", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockClientFindFirst.mockReset();
+    mockUpdate.mockReset();
+    mockSet.mockReset();
+    mockWhere.mockReset();
+    mockReturning.mockReset();
     // Reset chain
     mockUpdate.mockReturnValue({ set: mockSet });
     mockSet.mockReturnValue({ where: mockWhere });

--- a/src/lib/api/d2c-draft-helpers.ts
+++ b/src/lib/api/d2c-draft-helpers.ts
@@ -12,9 +12,9 @@
  * - Update is partial: only provided fields are overwritten.
  */
 
-import { and, desc, eq, isNull, sql } from "drizzle-orm";
+import { and, desc, eq, isNull } from "drizzle-orm";
 import { getDb } from "@/server/db";
-import { client, user } from "@/server/db/schemas";
+import { client } from "@/server/db/schemas";
 import type { ClientDraftFields } from "@/lib/d2c/client-adapter";
 
 /** Drizzle insert type for the client table. */
@@ -224,56 +224,34 @@ export async function createDraft(
     | { error: "INSERT_FAILED" | "RETRIEVE_FAILED" };
 
   try {
-    // Serialize draft creation per user to prevent duplicate drafts.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    result = await (db as any).transaction(async (tx: any) => {
-      await tx.execute(
-        sql`SELECT id FROM ${user} WHERE id = ${userId} FOR UPDATE`,
-      );
+    const [inserted] = await db
+      .insert(client)
+      .values(values)
+      .onConflictDoNothing()
+      .returning();
 
-      const existing = await tx.query.client.findFirst({
-        where: and(
-          eq(client.userId, userId),
-          eq(client.status, "draft"),
-          isNull(client.deletedAt),
-        ),
-        columns: DRAFT_SELECT_COLUMNS,
-        orderBy: [desc(client.updatedAt), desc(client.createdAt)],
-      });
-
-      if (existing) {
-        return { existed: true, draft: existing };
-      }
-
-      const [inserted] = await tx.insert(client).values(values).returning();
-
-      if (!inserted) {
-        return { error: "INSERT_FAILED" as const };
-      }
-
-      const draft = await tx.query.client.findFirst({
+    if (inserted) {
+      const draft = await db.query.client.findFirst({
         where: eq(client.id, inserted.id),
         columns: DRAFT_SELECT_COLUMNS,
       });
 
       if (!draft) {
-        return { error: "RETRIEVE_FAILED" as const };
+        console.error("[createDraft] Insert succeeded but re-fetch failed", {
+          userId,
+          insertedId: inserted.id,
+        });
+        result = { error: "RETRIEVE_FAILED" };
+      } else {
+        result = { existed: false, draft };
       }
-
-      return { existed: false, draft };
-    });
-  } catch (error) {
-    console.warn("[createDraft] Transaction path failed; using fallback", {
-      userId,
-      error:
-        error instanceof Error
-          ? { name: error.name, message: error.message }
-          : String(error),
-    });
-
-    try {
-      console.info("[createDraft] Fallback path engaged", { userId });
-
+    } else {
+      console.info(
+        "[createDraft] Insert conflicted; returning existing draft",
+        {
+          userId,
+        },
+      );
       const existing = await db.query.client.findFirst({
         where: and(
           eq(client.userId, userId),
@@ -287,22 +265,21 @@ export async function createDraft(
       if (existing) {
         result = { existed: true, draft: existing };
       } else {
-        console.error(
-          "[createDraft] Fallback could not find existing draft; refusing unsafe insert",
-          { userId },
-        );
+        console.error("[createDraft] Conflict without retrievable draft", {
+          userId,
+        });
         result = { error: "INSERT_FAILED" };
       }
-    } catch (fallbackError) {
-      console.error("[createDraft] Fallback path threw", {
-        userId,
-        error:
-          fallbackError instanceof Error
-            ? { name: fallbackError.name, message: fallbackError.message }
-            : String(fallbackError),
-      });
-      result = { error: "INSERT_FAILED" };
     }
+  } catch (error) {
+    console.error("[createDraft] Upsert path failed", {
+      userId,
+      error:
+        error instanceof Error
+          ? { name: error.name, message: error.message }
+          : String(error),
+    });
+    result = { error: "INSERT_FAILED" };
   }
 
   if (!result || "error" in result) {

--- a/src/lib/api/d2c-draft-helpers.ts
+++ b/src/lib/api/d2c-draft-helpers.ts
@@ -198,18 +198,16 @@ const DRAFT_DEFAULTS = {
   status: "draft" as const,
 };
 
-function d2cDraftPredicateByUser(userId: string) {
+function activeDraftPredicateByUser(userId: string) {
   return and(
     eq(client.userId, userId),
     eq(client.status, "draft"),
     isNull(client.deletedAt),
-    eq(client.firstName, ""),
-    eq(client.lastName, ""),
   );
 }
 
-function d2cDraftPredicateById(clientId: string, userId: string) {
-  return and(eq(client.id, clientId), d2cDraftPredicateByUser(userId));
+function activeDraftPredicateById(clientId: string, userId: string) {
+  return and(eq(client.id, clientId), activeDraftPredicateByUser(userId));
 }
 
 /**
@@ -246,7 +244,7 @@ export async function createDraft(
 
     if (inserted) {
       const draft = await db.query.client.findFirst({
-        where: d2cDraftPredicateById(inserted.id, userId),
+        where: activeDraftPredicateById(inserted.id, userId),
         columns: DRAFT_SELECT_COLUMNS,
       });
 
@@ -267,7 +265,7 @@ export async function createDraft(
         },
       );
       const existing = await db.query.client.findFirst({
-        where: d2cDraftPredicateByUser(userId),
+        where: activeDraftPredicateByUser(userId),
         columns: DRAFT_SELECT_COLUMNS,
         orderBy: [desc(client.updatedAt), desc(client.createdAt)],
       });

--- a/src/lib/api/d2c-draft-helpers.ts
+++ b/src/lib/api/d2c-draft-helpers.ts
@@ -198,6 +198,20 @@ const DRAFT_DEFAULTS = {
   status: "draft" as const,
 };
 
+function d2cDraftPredicateByUser(userId: string) {
+  return and(
+    eq(client.userId, userId),
+    eq(client.status, "draft"),
+    isNull(client.deletedAt),
+    eq(client.firstName, ""),
+    eq(client.lastName, ""),
+  );
+}
+
+function d2cDraftPredicateById(clientId: string, userId: string) {
+  return and(eq(client.id, clientId), d2cDraftPredicateByUser(userId));
+}
+
 /**
  * Creates a new draft client or returns the existing one.
  *
@@ -232,7 +246,7 @@ export async function createDraft(
 
     if (inserted) {
       const draft = await db.query.client.findFirst({
-        where: eq(client.id, inserted.id),
+        where: d2cDraftPredicateById(inserted.id, userId),
         columns: DRAFT_SELECT_COLUMNS,
       });
 
@@ -253,11 +267,7 @@ export async function createDraft(
         },
       );
       const existing = await db.query.client.findFirst({
-        where: and(
-          eq(client.userId, userId),
-          eq(client.status, "draft"),
-          isNull(client.deletedAt),
-        ),
+        where: d2cDraftPredicateByUser(userId),
         columns: DRAFT_SELECT_COLUMNS,
         orderBy: [desc(client.updatedAt), desc(client.createdAt)],
       });

--- a/src/server/db/schemas/clients-schema.ts
+++ b/src/server/db/schemas/clients-schema.ts
@@ -17,7 +17,9 @@ import {
   pgTable,
   text,
   timestamp,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 
 import { user } from "./auth-schema";
 import {
@@ -174,6 +176,10 @@ export const client = pgTable(
     index("client_deleted_at_idx").on(t.deletedAt),
     // Composite index for the most common query pattern: user's non-deleted clients
     index("client_user_id_deleted_at_idx").on(t.userId, t.deletedAt),
+    // Enforce at most one active draft per user at the DB layer.
+    uniqueIndex("client_one_active_draft_per_user_idx")
+      .on(t.userId)
+      .where(sql`${t.status} = 'draft' AND ${t.deletedAt} IS NULL`),
   ],
 );
 

--- a/src/server/db/schemas/clients-schema.ts
+++ b/src/server/db/schemas/clients-schema.ts
@@ -179,7 +179,9 @@ export const client = pgTable(
     // Enforce at most one active draft per user at the DB layer.
     uniqueIndex("client_one_active_draft_per_user_idx")
       .on(t.userId)
-      .where(sql`${t.status} = 'draft' AND ${t.deletedAt} IS NULL`),
+      .where(
+        sql`${t.status} = 'draft' AND ${t.deletedAt} IS NULL AND ${t.firstName} = '' AND ${t.lastName} = ''`,
+      ),
   ],
 );
 


### PR DESCRIPTION
## Summary
Fixes a production issue where users were being sent back to step 1 after completing step 3 of the apply flow.

## Root Cause
Draft creation (`POST /api/d2c/draft`) was failing in production (Vercel + Neon) due to use of:
- `transaction(...)`
- `SELECT ... FOR UPDATE`

These patterns are not reliable in serverless Postgres environments, causing:
- 500 errors on draft creation
- no draft to recover
- fallback GET returning 404
- user reset to intake (step 1)

## What Changed
- Removed transaction-based draft creation logic
- Removed `SELECT ... FOR UPDATE`
- Added DB-level uniqueness constraint:
  - one active draft per user (`status = 'draft' AND deleted_at IS NULL`)
- Switched to conflict-safe insert:
  - `insert(...).onConflictDoNothing()`
- On conflict:
  - fetch and return existing draft instead of attempting unsafe fallback insert
- Simplified logic and removed fallback paths

## Why This Fix Works
- Eliminates dependency on transaction/locking behavior unsupported in serverless DBs
- Ensures correctness at the database level (single-draft invariant)
- Makes draft creation idempotent and race-safe:
  - insert succeeds → new draft
  - conflict → existing draft returned
- Prevents the 500 → 404 → reset flow seen in production

## Database Changes
- Added unique partial index:
```sql
CREATE UNIQUE INDEX client_one_active_draft_per_user_idx
ON client (user_id)
WHERE status = 'draft' AND deleted_at IS NULL;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforces one active empty-name draft per user and automatically cleans up duplicate drafts.
* **Bug Fixes**
  * More reliable draft creation: reduced conflict errors and clearer failure reporting when a draft can't be retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->